### PR TITLE
Add Grammar lessons, save/resume progress, and forgot-password reset

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,7 +43,7 @@ const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) =
 };
 
 const PublicOnly: React.FC<{ children: React.ReactElement }> = ({ children }) => {
-  if (isAuthed()) return <Navigate to="/dashboard" replace />;
+  if (isAuthed()) return <Navigate to="/new-lessons" replace />;
   return children;
 };
 

--- a/client/src/components/AudioMatch.tsx
+++ b/client/src/components/AudioMatch.tsx
@@ -25,7 +25,10 @@ const AudioMatch: React.FC<AudioMatchProps> = ({
   const [playCount, setPlayCount] = useState(0);
   const [selected, setSelected] = useState<string | null>(null);
 
-  const choices = useMemo(() => options ?? [], [options]);
+  // Deduped defensively — callers should already pass unique options, but a
+  // duplicate here would otherwise render two identical, independently-
+  // clickable answer buttons.
+  const choices = useMemo(() => Array.from(new Set(options ?? [])), [options]);
 
   const play = () => {
     if (!audioUrl || !audioRef.current) return;

--- a/client/src/components/Flips.tsx
+++ b/client/src/components/Flips.tsx
@@ -1,38 +1,42 @@
-import React, { useMemo, useRef, useState } from "react";
-import { Box, Button, Grid, IconButton, Typography, useMediaQuery, useTheme } from "@mui/material";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Box, Grid, IconButton, Typography, useMediaQuery, useTheme } from "@mui/material";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
-import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 
 type CardData = { id: number; front: string; back?: string; audio?: string };
 
 type FlipsProps = {
   onResult?: (r: { result: "correct" | "incorrect"; detail?: any }) => void;
   prompt?: string;
-  correctCardId?: number;
   cards?: CardData[];
 };
 
 const defaultCards: CardData[] = [
-  { id: 0, front: "あ / ア", back: "Looks like an apple" },
-  { id: 1, front: "い / イ", back: "Looks like an ear" },
-  { id: 2, front: "う / ウ", back: "Looks like a punch" },
+  { id: 0, front: "あ / ア" },
+  { id: 1, front: "い / イ" },
+  { id: 2, front: "う / ウ" },
 ];
+
+// Cards like "あ / ア" show one character on each face of the flashcard.
+function splitFaces(card: CardData): { frontFace: string; backFace: string } {
+  const parts = card.front.split("/").map((s) => s.trim()).filter(Boolean);
+  if (parts.length > 1) {
+    return { frontFace: parts[0], backFace: parts[1] };
+  }
+  return { frontFace: card.front, backFace: card.back || card.front };
+}
 
 const Flips: React.FC<FlipsProps> = ({
   onResult,
-  prompt = "Flip each card to review, then select the correct one.",
-  correctCardId = 0,
+  prompt = "Flip each card to review.",
   cards = defaultCards,
 }) => {
   const [flipped, setFlipped] = useState<Record<number, boolean>>({});
-  const [selected, setSelected] = useState<number | null>(null);
-  const answeredRef = useRef(false);
+  const completedRef = useRef(false);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const toggleFlip = (id: number) => {
-    if (answeredRef.current) return;
     setFlipped((p) => ({ ...p, [id]: !p[id] }));
   };
 
@@ -42,18 +46,13 @@ const Flips: React.FC<FlipsProps> = ({
   };
 
   const allFlipped = useMemo(() => cards.every((c) => flipped[c.id]), [cards, flipped]);
-  const flippedCount = useMemo(() => cards.filter((c) => flipped[c.id]).length, [cards, flipped]);
 
-  const selectAnswer = (pickedId: number) => {
-    if (answeredRef.current || !allFlipped) return;
-    answeredRef.current = true;
-    setSelected(pickedId);
-    const correct = pickedId === correctCardId;
-    onResult?.({
-      result: correct ? "correct" : "incorrect",
-      detail: { pickedId, correctCardId, flippedIds: Object.keys(flipped).map(Number) },
-    });
-  };
+  useEffect(() => {
+    if (allFlipped && !completedRef.current) {
+      completedRef.current = true;
+      onResult?.({ result: "correct", detail: { allFlipped: true } });
+    }
+  }, [allFlipped, onResult]);
 
   if (!cards.length) return <Box p={3}><Typography>No cards to display.</Typography></Box>;
 
@@ -63,11 +62,6 @@ const Flips: React.FC<FlipsProps> = ({
       <Box sx={{ textAlign: "center", mb: 3 }}>
         <Typography sx={{ fontWeight: 700, fontSize: { xs: "1rem", sm: "1.1rem" }, color: "#1C1917" }}>
           {prompt}
-        </Typography>
-        <Typography variant="body2" sx={{ mt: 0.75, color: "text.secondary" }}>
-          {allFlipped
-            ? "All flipped! Select the one you want."
-            : `${flippedCount} / ${cards.length} flipped — keep going.`}
         </Typography>
 
         {/* Mini progress pips */}
@@ -91,14 +85,7 @@ const Flips: React.FC<FlipsProps> = ({
       <Grid container spacing={{ xs: 2, sm: 2.5 }} justifyContent="center">
         {cards.map((card) => {
           const isFlipped = !!flipped[card.id];
-          const backContent = card.back || card.front;
-          const isSelected = selected === card.id;
-          const isCorrectCard = card.id === correctCardId;
-          const showResult = selected !== null;
-
-          let borderColor = "rgba(0,0,0,0.1)";
-          if (showResult && isSelected) borderColor = isCorrectCard ? "#059669" : "#DC2626";
-          if (showResult && !isSelected && isCorrectCard) borderColor = "#059669";
+          const { frontFace, backFace } = splitFaces(card);
 
           return (
             <Grid item key={card.id} xs={12} sm={6} md={4} display="flex" justifyContent="center">
@@ -112,7 +99,7 @@ const Flips: React.FC<FlipsProps> = ({
                     width: isMobile ? "100%" : 220,
                     maxWidth: 260,
                     height: 180,
-                    cursor: answeredRef.current ? "default" : "pointer",
+                    cursor: "pointer",
                   }}
                 >
                   <Box
@@ -136,17 +123,17 @@ const Flips: React.FC<FlipsProps> = ({
                         alignItems: "center",
                         justifyContent: "center",
                         gap: 1,
-                        border: `2px solid ${borderColor}`,
+                        border: "2px solid rgba(0,0,0,0.1)",
                         borderRadius: "16px",
                         bgcolor: "#FFFFFF",
                         boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
                         userSelect: "none",
-                        transition: "border-color 0.3s, box-shadow 0.2s",
-                        "&:hover": answeredRef.current ? {} : { boxShadow: "0 4px 20px rgba(0,0,0,0.13)" },
+                        transition: "box-shadow 0.2s",
+                        "&:hover": { boxShadow: "0 4px 20px rgba(0,0,0,0.13)" },
                       }}
                     >
                       <Typography sx={{ fontSize: "2rem", fontWeight: 700, letterSpacing: "-0.02em" }}>
-                        {card.front}
+                        {frontFace}
                       </Typography>
                       <Typography variant="caption" sx={{ color: "text.secondary", fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", fontSize: "0.65rem" }}>
                         Tap to flip
@@ -160,59 +147,33 @@ const Flips: React.FC<FlipsProps> = ({
                         inset: 0,
                         backfaceVisibility: "hidden",
                         display: "flex",
+                        flexDirection: "column",
                         alignItems: "center",
                         justifyContent: "center",
-                        border: "2px solid #B43D20",
+                        gap: 1,
+                        border: "2px solid rgba(0,0,0,0.1)",
                         borderRadius: "16px",
-                        bgcolor: "rgba(180,61,32,0.04)",
-                        boxShadow: "0 2px 12px rgba(180,61,32,0.12)",
-                        fontSize: backContent.length > 24 ? "0.9rem" : "1.05rem",
-                        fontWeight: 600,
-                        px: 2.5,
-                        textAlign: "center",
+                        bgcolor: "#FFFFFF",
+                        boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
                         userSelect: "none",
                         transform: "rotateY(180deg)",
-                        color: "#1C1917",
-                        lineHeight: 1.4,
                       }}
                     >
-                      {backContent}
+                      <Typography sx={{ fontSize: "2rem", fontWeight: 700, letterSpacing: "-0.02em" }}>
+                        {backFace}
+                      </Typography>
+                      <Typography variant="caption" sx={{ color: "text.secondary", fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", fontSize: "0.65rem" }}>
+                        Tap to flip
+                      </Typography>
                     </Box>
                   </Box>
                 </Box>
 
-                {/* Select button / result indicator */}
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  {card.audio && (
-                    <IconButton size="small" onClick={() => playAudio(card.audio)} sx={{ color: "#B43D20" }}>
-                      <VolumeUpIcon fontSize="small" />
-                    </IconButton>
-                  )}
-
-                  {showResult && isCorrectCard ? (
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, color: "#059669" }}>
-                      <CheckCircleRoundedIcon fontSize="small" />
-                      <Typography variant="body2" sx={{ fontWeight: 700 }}>Correct</Typography>
-                    </Box>
-                  ) : (
-                    <Button
-                      variant={isSelected ? "contained" : "outlined"}
-                      size="small"
-                      onClick={() => selectAnswer(card.id)}
-                      disabled={!allFlipped || answeredRef.current}
-                      sx={{
-                        borderRadius: 999,
-                        fontWeight: 700,
-                        fontSize: "0.78rem",
-                        px: 2,
-                        ...(isSelected && !isCorrectCard && { bgcolor: "#DC2626", borderColor: "#DC2626", "&:hover": { bgcolor: "#B91C1C" } }),
-                        ...(!answeredRef.current && allFlipped && { borderColor: "#B43D20", color: "#B43D20", "&:hover": { bgcolor: "rgba(180,61,32,0.06)" } }),
-                      }}
-                    >
-                      Select
-                    </Button>
-                  )}
-                </Box>
+                {card.audio && (
+                  <IconButton size="small" onClick={() => playAudio(card.audio)} sx={{ color: "#B43D20" }}>
+                    <VolumeUpIcon fontSize="small" />
+                  </IconButton>
+                )}
               </Box>
             </Grid>
           );

--- a/client/src/components/MatchAudioExercisePlaceholder.tsx
+++ b/client/src/components/MatchAudioExercisePlaceholder.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { Box, Chip, Typography } from "@mui/material";
 import VolumeUpRoundedIcon from "@mui/icons-material/VolumeUpRounded";
 import GraphicEqRoundedIcon from "@mui/icons-material/GraphicEqRounded";
 import ImageRoundedIcon from "@mui/icons-material/ImageRounded";
 import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { ChoiceCandidate } from "../utils/expandLessonItems";
 
 const BRAND = "#B43D20";
 
@@ -13,11 +14,13 @@ export interface MatchAudioItem {
   phrase: string;
   audioUrl?: string;
   imageUrl?: string;
+  // Other terms learned since the last checkpoint (or since the start of the
+  // lesson) — the pool the 2 wrong-answer images are drawn from.
+  checkpointPool?: ChoiceCandidate[];
 }
 
 interface Props {
   item: MatchAudioItem;
-  allItems: MatchAudioItem[];
   onResult?: (r: { result: "correct" | "incorrect"; detail?: any }) => void;
 }
 
@@ -25,29 +28,38 @@ function isPlaceholder(url?: string) {
   return !url || url.toUpperCase().includes("PLACEHOLDER");
 }
 
-// Deterministic position for the correct answer based on phrase content,
-// so each exercise has a different correct-button position.
-function correctPosition(phrase: string): number {
-  let hash = 0;
-  for (let i = 0; i < phrase.length; i++) {
-    hash = (hash * 31 + phrase.charCodeAt(i)) & 0xffff;
-  }
-  return hash % 3;
-}
-
-// Seeded shuffle — stable across renders for the same phrase.
-function seededShuffle<T>(arr: T[], seed: number): T[] {
+function randomShuffle<T>(arr: T[]): T[] {
   const out = [...arr];
-  let s = seed;
   for (let i = out.length - 1; i > 0; i--) {
-    s = (s * 1664525 + 1013904223) & 0xffffffff;
-    const j = Math.abs(s) % (i + 1);
+    const j = Math.floor(Math.random() * (i + 1));
     [out[i], out[j]] = [out[j], out[i]];
   }
   return out;
 }
 
-const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, allItems, onResult }) => {
+// The correct term plus up to 2 random, DISTINCT distractors from the
+// checkpoint pool, in a freshly randomised order — recomputed every time the
+// exercise is presented (see the useState lazy initializer below), not
+// derived from the phrase. Never pads with a duplicate of the correct answer
+// (or of a distractor already picked) — if fewer than 2 distinct distractors
+// exist, the exercise simply shows fewer than 3 tiles.
+function buildChoices(item: MatchAudioItem): ChoiceCandidate[] {
+  const correct: ChoiceCandidate = { phrase: item.phrase, imageUrl: item.imageUrl };
+  const pool = item.checkpointPool ?? [];
+
+  const seenPhrases = new Set<string>([item.phrase]);
+  const distractorCandidates: ChoiceCandidate[] = [];
+  for (const c of pool) {
+    if (seenPhrases.has(c.phrase)) continue;
+    seenPhrases.add(c.phrase);
+    distractorCandidates.push(c);
+  }
+
+  const distractors = randomShuffle(distractorCandidates).slice(0, 2);
+  return randomShuffle([correct, ...distractors]);
+}
+
+const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, onResult }) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [playing, setPlaying] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
@@ -62,22 +74,12 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, allItems, onResu
     audioRef.current.play().catch(() => setPlaying(false));
   };
 
-  // Build 3 choices: correct + 2 distractors, correct at deterministic position.
-  const choices = useMemo(() => {
-    const distractorPool = allItems.filter((a) => a.phrase !== item.phrase);
-    const seed = item.phrase.split("").reduce((acc, c) => acc * 31 + c.charCodeAt(0), 0);
-    const shuffled = seededShuffle(distractorPool, seed);
-    const distractors = shuffled.slice(0, 2);
+  // Computed once when this exercise is first presented (lazy initializer —
+  // never recomputed on re-render), so the correct answer's position and the
+  // 2 distractors are freshly randomised every time the exercise is shown.
+  const [choices] = useState<ChoiceCandidate[]>(() => buildChoices(item));
 
-    const pos = correctPosition(item.phrase);
-    const result: MatchAudioItem[] = [...distractors];
-    result.splice(pos, 0, item);
-    // Pad with current item if not enough distractors
-    while (result.length < 3) result.push(item);
-    return result;
-  }, [item, allItems]);
-
-  const handleChoice = (choice: MatchAudioItem) => {
+  const handleChoice = (choice: ChoiceCandidate) => {
     if (selected || wrongFlash) return;
     if (choice.phrase === item.phrase) {
       setSelected(choice.phrase);
@@ -89,7 +91,7 @@ const MatchAudioExercisePlaceholder: React.FC<Props> = ({ item, allItems, onResu
     }
   };
 
-  const getState = (choice: MatchAudioItem) => {
+  const getState = (choice: ChoiceCandidate) => {
     if (selected && choice.phrase === item.phrase) return "correct";
     if (wrongFlash === choice.phrase) return "wrong";
     return "idle";

--- a/client/src/components/MatchDots.tsx
+++ b/client/src/components/MatchDots.tsx
@@ -198,7 +198,7 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
   const containerHeight = pairs.length * ROW_HEIGHT;
 
   return (
-    <Box sx={{ textAlign: "center", p: { xs: 1, sm: 2 }, width: "100%" }}>
+    <Box sx={{ textAlign: "center", p: { xs: 1, sm: 2 }, width: "100%", overflowX: "hidden" }}>
       <Typography sx={{ fontWeight: 700, fontSize: { xs: "1rem", sm: "1.1rem" }, mb: 0.75, color: "#1C1917" }}>
         Match each hiragana to its katakana
       </Typography>

--- a/client/src/components/MatchDots.tsx
+++ b/client/src/components/MatchDots.tsx
@@ -12,6 +12,45 @@ type DotMatchProps = {
 
 const DOT_SIZE = 14;
 
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// Shuffles `pool` so that, as much as possible, no item ends up on the same
+// row it occupies in `reference` — this keeps the correct right-column
+// answer from lining up on the same row as its left-column term.
+function derangeRelativeTo(reference: number[], pool: number[]): number[] {
+  if (pool.length <= 1) return shuffle(pool);
+
+  let result = shuffle(pool);
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (result.every((v, i) => v !== reference[i])) return result;
+    result = shuffle(pool);
+  }
+
+  // Fallback: targeted swaps to remove any remaining same-row matches.
+  for (let i = 0; i < result.length; i++) {
+    if (result[i] !== reference[i]) continue;
+    const j = result.findIndex(
+      (v, idx) => idx !== i && v !== reference[i] && result[i] !== reference[idx]
+    );
+    if (j !== -1) [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+function buildArrangement(pairs: DotMatchPair[]): { leftOrder: number[]; rightOrder: number[] } {
+  const ids = pairs.map((_, i) => i);
+  const leftOrder = shuffle(ids);
+  const rightOrder = derangeRelativeTo(leftOrder, ids);
+  return { leftOrder, rightOrder };
+}
+
 const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -22,8 +61,22 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
   const [submitted, setSubmitted] = useState(false);
   const [correctSet, setCorrectSet] = useState<Set<string>>(new Set());
 
-  const leftLabels = useMemo(() => pairs.map((p) => p.hiragana), [pairs]);
-  const rightLabels = useMemo(() => pairs.map((p) => p.katakana), [pairs]);
+  // Randomized once per mount so the layout is fresh on every attempt.
+  const [{ leftOrder, rightOrder }] = useState(() => buildArrangement(pairs));
+
+  const leftLabels = useMemo(() => leftOrder.map((pairId) => pairs[pairId].hiragana), [leftOrder, pairs]);
+  const rightLabels = useMemo(() => rightOrder.map((pairId) => pairs[pairId].katakana), [rightOrder, pairs]);
+
+  // Row index on the right column holding the correct katakana for each left row.
+  const correctRightRowForLeftRow = useMemo(
+    () => leftOrder.map((pairId) => rightOrder.indexOf(pairId)),
+    [leftOrder, rightOrder]
+  );
+  // Row index on the left column holding the correct hiragana for each right row.
+  const correctLeftRowForRightRow = useMemo(
+    () => rightOrder.map((pairId) => leftOrder.indexOf(pairId)),
+    [leftOrder, rightOrder]
+  );
 
   const getLineColor = (dot1Id: string, dot2Id: string): string => {
     if (!submitted) return "#B43D20";
@@ -124,7 +177,9 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
 
   const handleCheck = () => {
     const made = new Set(connections.map((c) => `${c.dot1Id}-${c.dot2Id}`));
-    const expected = new Set(leftLabels.map((_, i) => `L${i + 1}-R${i + 1}`));
+    const expected = new Set(
+      correctRightRowForLeftRow.map((rightRow, leftRow) => `L${leftRow + 1}-R${rightRow + 1}`)
+    );
     const allCorrect = expected.size === made.size && [...expected].every((k) => made.has(k));
     setCorrectSet(expected);
     setSubmitted(true);
@@ -178,7 +233,8 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
             const id = `L${i + 1}`;
             const active = firstId === id;
             const connected = isConnected(id);
-            const isCorrect = submitted && correctSet.has(`${id}-R${i + 1}`) && connections.some((c) => c.dot1Id === id && c.dot2Id === `R${i + 1}`);
+            const expectedRId = `R${correctRightRowForLeftRow[i] + 1}`;
+            const isCorrect = submitted && connections.some((c) => c.dot1Id === id && c.dot2Id === expectedRId);
             const isWrong = submitted && connected && !isCorrect;
 
             return (
@@ -229,7 +285,7 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, onResult }) => {
             const connected = isConnected(id);
             // Find what L dot is connected to this R dot
             const connectedL = connections.find((c) => c.dot2Id === id)?.dot1Id;
-            const expectedL = `L${i + 1}`;
+            const expectedL = `L${correctLeftRowForRightRow[i] + 1}`;
             const isCorrect = submitted && connectedL === expectedL;
             const isWrong = submitted && connected && !isCorrect;
 

--- a/client/src/components/MatchDotsMedia.tsx
+++ b/client/src/components/MatchDotsMedia.tsx
@@ -148,7 +148,7 @@ const MatchDotsMedia: React.FC<Props> = ({ pairs, instructions, onResult }) => {
   const containerHeight = pairs.length * ROW_HEIGHT;
 
   return (
-    <Box sx={{ textAlign: "center", p: { xs: 1, sm: 2 }, width: "100%" }}>
+    <Box sx={{ textAlign: "center", p: { xs: 1, sm: 2 }, width: "100%", overflowX: "hidden" }}>
       <Typography sx={{ fontWeight: 700, fontSize: { xs: "1rem", sm: "1.1rem" }, mb: 0.75, color: "#1C1917" }}>
         {instructions || "Match phrase to appropriate situation — connect the dots"}
       </Typography>

--- a/client/src/components/NewLessonPageItem.tsx
+++ b/client/src/components/NewLessonPageItem.tsx
@@ -29,7 +29,7 @@ function normaliseNewTerms(raw: any): NewTerm[] {
     .map((t): NewTerm | null => {
       if (typeof t === "string") return { term: t };
       if (t && typeof t === "object") {
-        const term = t.term ?? t.word ?? t.text ?? "";
+        const term = t.term ?? t.word ?? t.text ?? t.Title ?? t.title ?? "";
         if (!term) return null;
         return {
           term: String(term),
@@ -87,13 +87,17 @@ const NewTermVideo: React.FC<{ videoUrl?: string }> = ({ videoUrl }) => {
   );
 };
 
-// A single new-term row with a video placeholder and an audio button,
-// mirroring FlashcardReview's native-<audio> playback pattern (VolumeUp →
-// GraphicEq while playing).
-const NewTermRow: React.FC<{ term: NewTerm }> = ({ term }) => {
+// A clickable pronunciation button, mirroring FlashcardReview's native-<audio>
+// playback pattern (VolumeUp → GraphicEq while playing). Reused for both the
+// per-term rows below and the single term introduced by a page's title.
+const TermAudioButton: React.FC<{ audioUrl?: string; label: string; size?: number }> = ({
+  audioUrl,
+  label,
+  size = 40,
+}) => {
   const [playing, setPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const hasAudio = !isPlaceholderUrl(term.audioUrl);
+  const hasAudio = !isPlaceholderUrl(audioUrl);
 
   const playAudio = () => {
     if (!hasAudio || !audioRef.current) return;
@@ -103,38 +107,17 @@ const NewTermRow: React.FC<{ term: NewTerm }> = ({ term }) => {
   };
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        gap: 1.5,
-        px: 2,
-        py: 1.25,
-        borderRadius: "12px",
-        border: "1px solid rgba(180,61,32,0.15)",
-        bgcolor: "rgba(180,61,32,0.03)",
-      }}
-    >
+    <>
       {hasAudio && (
-        <audio
-          ref={audioRef}
-          src={term.audioUrl}
-          preload="auto"
-          onEnded={() => setPlaying(false)}
-        />
+        <audio ref={audioRef} src={audioUrl} preload="auto" onEnded={() => setPlaying(false)} />
       )}
-
-      {/* Video placeholder / embed */}
-      <NewTermVideo videoUrl={term.videoUrl} />
-
-      {/* Audio button */}
       <Box
         onClick={playAudio}
         role="button"
-        aria-label={`Play pronunciation of ${term.term}`}
+        aria-label={`Play pronunciation of ${label}`}
         sx={{
-          width: 40,
-          height: 40,
+          width: size,
+          height: size,
           flexShrink: 0,
           borderRadius: "50%",
           bgcolor: hasAudio ? BRAND : "rgba(0,0,0,0.1)",
@@ -152,9 +135,32 @@ const NewTermRow: React.FC<{ term: NewTerm }> = ({ term }) => {
         }}
       >
         {playing
-          ? <GraphicEqRoundedIcon sx={{ color: "#fff", fontSize: "1.2rem" }} />
-          : <VolumeUpRoundedIcon sx={{ color: hasAudio ? "#fff" : "rgba(0,0,0,0.25)", fontSize: "1.2rem" }} />}
+          ? <GraphicEqRoundedIcon sx={{ color: "#fff", fontSize: size * 0.3 }} />
+          : <VolumeUpRoundedIcon sx={{ color: hasAudio ? "#fff" : "rgba(0,0,0,0.25)", fontSize: size * 0.3 }} />}
       </Box>
+    </>
+  );
+};
+
+// A single new-term row with a video placeholder and an audio button.
+const NewTermRow: React.FC<{ term: NewTerm }> = ({ term }) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        px: 2,
+        py: 1.25,
+        borderRadius: "12px",
+        border: "1px solid rgba(180,61,32,0.15)",
+        bgcolor: "rgba(180,61,32,0.03)",
+      }}
+    >
+      {/* Video placeholder / embed */}
+      <NewTermVideo videoUrl={term.videoUrl} />
+
+      <TermAudioButton audioUrl={term.audioUrl} label={term.term} />
 
       {/* Term + optional definition */}
       <Box sx={{ minWidth: 0 }}>
@@ -321,12 +327,21 @@ const NewLessonPageItem: React.FC<Props> = ({ item }) => {
           </Box>
         )}
 
-        {/* Title */}
-        <Typography
-          sx={{ fontWeight: 900, fontSize: "1.1rem", color: "#1C1917", mb: 2, letterSpacing: "-0.01em" }}
-        >
-          {title}
-        </Typography>
+        {/* Title + pronunciation button for the term this page introduces,
+            with its optional description shown inline in smaller text. */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2, flexWrap: "wrap" }}>
+          <Typography
+            sx={{ fontWeight: 900, fontSize: "1.1rem", color: "#1C1917", letterSpacing: "-0.01em" }}
+          >
+            {title}
+          </Typography>
+          <TermAudioButton audioUrl={item.audioUrl ?? item.audioURL ?? item.audio} label={title} size={32} />
+          {item.description && (
+            <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", lineHeight: 1.4 }}>
+              — {item.description}
+            </Typography>
+          )}
+        </Box>
 
         {/* Transcript */}
         <Box

--- a/client/src/pages/AuthForm.tsx
+++ b/client/src/pages/AuthForm.tsx
@@ -106,7 +106,7 @@ const AuthForm = (): React.ReactElement => {
       setToken(data.token);
 
       notify("Login successful. Redirecting…", "success");
-      const redirectTo = location.state?.from?.pathname || "/dashboard";
+      const redirectTo = location.state?.from?.pathname || "/new-lessons";
 
       // IMPORTANT: full reload so header + guards pick up localStorage immediately
       window.location.assign(redirectTo);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -626,6 +626,9 @@ const Dashboard = (): React.ReactElement => {
           </Box>
         </Box>
 
+        {/* ── Practice panel ─────────────────────────────────────────────── */}
+        
+
         {/* ── Stories panel ─────────────────────────────────────────────── */}
         <Box
           sx={{

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import {
   CardContent,
   Typography,
   Button,
+  
   Container,
   Stack,
   Grid,

--- a/client/src/pages/Lesson.tsx
+++ b/client/src/pages/Lesson.tsx
@@ -26,7 +26,7 @@ import Fact from "../components/Fact";
 import Reward from "../components/Rewards";
 import RInfo from "../components/RewardInfo";
 
-import { submitAttempt, upsertProgress } from "../services/progress";
+import { submitAttempt, upsertProgress, getProgress } from "../services/progress";
 import { isAuthed, safe } from "../services/api";
 import { getLesson, LessonDoc } from "../services/lessons";
 
@@ -112,6 +112,8 @@ function resolveLessonIdentifier(lesson: LessonDoc): string {
 }
 
 function getLessonHeader(lesson: LessonDoc): string {
+  const cardTitle = String((lesson as any).cardTitle || "").trim();
+  if (cardTitle) return cardTitle;
   const t = String((lesson as any).title || "Lesson");
   const v = String((lesson as any).version || "");
   return v ? `${t} (${v})` : t;
@@ -168,9 +170,11 @@ const Lesson: React.FC = () => {
   const [attemptCount, setAttemptCount] = useState(0);
 
   const answeredStepRef = useRef<Record<string, boolean>>({});
+  const resumedRef = useRef(false);
 
   useEffect(() => {
     let mounted = true;
+    resumedRef.current = false;
 
     void (async (): Promise<void> => {
       try {
@@ -337,22 +341,26 @@ const Lesson: React.FC = () => {
   const pct = steps.length ? Math.round(((step + 1) / steps.length) * 100) : 0;
   const accuracy = attemptCount ? Math.round((100 * correctCount) / attemptCount) : 0;
 
+  // Resume at the last-seen step, since exercise order here is authored and
+  // stable (unlike the Grammar flow, no re-shuffling happens), so the saved
+  // raw index is safe to reuse directly. Runs once per lesson load.
   useEffect(() => {
-    if (!lesson || !isAuthed() || !lessonKey) return;
+    if (!lesson || !isAuthed() || !lessonKey || !steps.length || resumedRef.current) return;
+    resumedRef.current = true;
 
+    let cancelled = false;
     void (async (): Promise<void> => {
       try {
-        await upsertProgress({
-          lessonId: lessonKey,
-          status: "in_progress",
-          lastStep: 0,
-          accuracyPct: 0,
-        });
+        const saved = await getProgress(lessonKey);
+        if (!cancelled && saved && saved.status === "in_progress" && saved.lastStep > 0 && saved.lastStep < steps.length) {
+          setStep(saved.lastStep);
+        }
       } catch (e) {
-        console.error("[Progress] upsert failed:", e);
+        console.error("[Progress] fetch failed:", e);
       }
     })();
-  }, [lesson, lessonKey]);
+    return () => { cancelled = true; };
+  }, [lesson, lessonKey, steps]);
 
   function advance({
     result,
@@ -403,7 +411,7 @@ const Lesson: React.FC = () => {
         });
       }
 
-      navigate("/dashboard");
+      navigate("/new-lessons");
     }
   }
 
@@ -461,6 +469,19 @@ const Lesson: React.FC = () => {
     if (prevKey) delete answeredStepRef.current[prevKey];
 
     setStep(prevStep);
+  };
+
+  const handleSaveAndExit = () => {
+    if (lesson && isAuthed() && lessonKey) {
+      void upsertProgress({
+        lessonId: lessonKey,
+        status: "in_progress",
+        lastStep: step,
+        stepKey: steps[step]?.key,
+        accuracyPct: accuracy,
+      }).catch((e) => console.error("[Progress] save failed:", e));
+    }
+    navigate("/new-lessons");
   };
 
   if (loading) {
@@ -537,7 +558,7 @@ const Lesson: React.FC = () => {
             <Button
               startIcon={<ArrowBackRoundedIcon />}
               variant="text"
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/new-lessons")}
               sx={{
                 fontWeight: 700,
                 color: "text.secondary",
@@ -561,12 +582,6 @@ const Lesson: React.FC = () => {
               </Typography>
 
               <Stack direction="row" alignItems="center" gap={0.75} flexWrap="wrap" sx={{ mt: 0.25 }}>
-                <Chip
-                  size="small"
-                  label={`${stepIcon(activeKey)} ${activeLabel} · ${step + 1}/${steps.length}`}
-                  sx={{ fontWeight: 700, fontSize: "0.72rem", height: 22 }}
-                />
-
                 {attemptCount > 0 && (
                   <Chip
                     size="small"
@@ -598,7 +613,7 @@ const Lesson: React.FC = () => {
                 startIcon={<LogoutRoundedIcon />}
                 variant="contained"
                 size="small"
-                onClick={() => navigate("/new-lessons")}
+                onClick={handleSaveAndExit}
                 sx={{
                   bgcolor: "#B43D20",
                   "&:hover": { bgcolor: "#9D351C" },

--- a/client/src/pages/Lesson.tsx
+++ b/client/src/pages/Lesson.tsx
@@ -38,7 +38,6 @@ type CardData = { id: number; front: string; back: string; audio?: string };
 interface FlipsProps {
   onResult?: ResultCb;
   prompt?: string;
-  correctCardId?: number;
   cards?: CardData[];
 }
 
@@ -239,18 +238,7 @@ const Lesson: React.FC = () => {
             back: "",
           }));
 
-          const correctRaw = String((lesson as any).flashcardsCorrect || flashcards[0] || "");
-          const idx = flashcards.findIndex((x) => x === correctRaw);
-          const correctId = idx >= 0 ? idx : 0;
-
-          return (
-            <FlipsC
-              onResult={on}
-              prompt="Flip the cards, then select the correct one."
-              cards={cardData}
-              correctCardId={correctId}
-            />
-          );
+          return <FlipsC onResult={on} prompt="Flip each card to review." cards={cardData} />;
         },
       });
     }
@@ -271,7 +259,10 @@ const Lesson: React.FC = () => {
       }
 
       if (exType === "matchAudioLetter") {
-        const options = (ex.items || []).map(normalizeChoiceLabel);
+        // Dedupe so the same answer never appears twice among the choices —
+        // source data (ex.items) isn't guaranteed unique.
+        const rawOptions: string[] = (ex.items || []).map(normalizeChoiceLabel);
+        const options = Array.from(new Set(rawOptions));
         const correctAnswer = normalizeChoiceLabel((ex.correctAnswers || [])[0] || options[0] || "");
 
         out.push({

--- a/client/src/pages/NewLessonPage.tsx
+++ b/client/src/pages/NewLessonPage.tsx
@@ -23,6 +23,7 @@ import Fact from "../components/Fact";
 
 import { getNewLesson, NewLessonDoc, NewLessonItem } from "../services/newLessons";
 import { expandLessonItems } from "../utils/expandLessonItems";
+import { isPlaceholderUrl } from "../utils/termMedia";
 
 // ── Step helpers (mirrors Lesson.tsx conventions) ────────────────────────────
 
@@ -83,12 +84,16 @@ function renderItem(
 
   if (type === "dragAndDropExercise") {
     const term = (item as any)._term as string | undefined;
+    const rawAudioUrl = (item as any).audioUrl as string | undefined;
+    const rawImageUrl = (item as any).imageUrl as string | undefined;
     const placeholderBank = ["〇", "〇", "〇", "〇", "〇"];
     return (
       <DragDrop
         prompt={term ? `Build: "${term}"` : ((item as any).description || "Build the correct phrase")}
         characterBank={placeholderBank}
         correctAnswer="〇〇〇"
+        audioUrl={isPlaceholderUrl(rawAudioUrl) ? undefined : rawAudioUrl}
+        imageUrl={isPlaceholderUrl(rawImageUrl) ? undefined : rawImageUrl}
         onResult={onResult}
       />
     );

--- a/client/src/pages/NewLessonPage.tsx
+++ b/client/src/pages/NewLessonPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   Container,
   LinearProgress,
@@ -24,32 +23,31 @@ import Fact from "../components/Fact";
 import { getNewLesson, NewLessonDoc, NewLessonItem } from "../services/newLessons";
 import { expandLessonItems } from "../utils/expandLessonItems";
 import { isPlaceholderUrl } from "../utils/termMedia";
+import { getProgress, upsertProgress } from "../services/progress";
+import { isAuthed } from "../services/api";
 
-// ── Step helpers (mirrors Lesson.tsx conventions) ────────────────────────────
-
-function stepLabelFromType(type: string): string {
+// A content-derived key identifying a specific exercise, stable across
+// re-expansions of the same lesson even though matchAudio/pronunciation/
+// dragAndDrop items are re-shuffled on every visit. Used to resume at the
+// same exercise the user last saw, rather than a raw (unstable) index.
+function stepKeyForItem(item: NewLessonItem): string {
+  const type = item.type as string;
+  const any = item as any;
   switch (type) {
-    case "page": return "Lesson";
-    case "pronunciationExercise": return "Pronunciation";
-    case "matchingExercise": return "Matching";
-    case "matchAudioExercise": return "Listen";
-    case "dragAndDropExercise": return "Drag & Drop";
-    case "infoBreak": return "Note";
-    case "lifeUsefulFact": return "Life Tip";
-    default: return "Step";
-  }
-}
-
-function stepIconFromType(type: string): string {
-  switch (type) {
-    case "page": return "📖";
-    case "pronunciationExercise": return "🎙";
-    case "matchingExercise": return "🔗";
-    case "matchAudioExercise": return "🎧";
-    case "dragAndDropExercise": return "✋";
-    case "infoBreak": return "💡";
-    case "lifeUsefulFact": return "🌟";
-    default: return "📌";
+    case "page":
+      return `page:${any.title || ""}`;
+    case "matchAudioExercise":
+    case "pronunciationExercise":
+      return `${type}:${any.phrase || ""}`;
+    case "matchingExercise":
+      return `matchingExercise:${(any.items || []).map((m: any) => m.phrase).join("|")}`;
+    case "dragAndDropExercise":
+      return `dragAndDropExercise:${any._term || any.phrase || any.term || ""}`;
+    case "infoBreak":
+    case "lifeUsefulFact":
+      return `${type}:${String(any.content || "").slice(0, 40)}`;
+    default:
+      return `${type}:${any.number ?? ""}`;
   }
 }
 
@@ -57,8 +55,7 @@ function stepIconFromType(type: string): string {
 
 function renderItem(
   item: NewLessonItem,
-  onResult: (r: { result: "correct" | "incorrect" }) => void,
-  allMatchAudioItems: any[]
+  onResult: (r: { result: "correct" | "incorrect" }) => void
 ): React.ReactNode {
   const type = item.type as string;
 
@@ -79,7 +76,7 @@ function renderItem(
   }
 
   if (type === "matchAudioExercise") {
-    return <MatchAudioExercisePlaceholder item={item as any} allItems={allMatchAudioItems} onResult={onResult} />;
+    return <MatchAudioExercisePlaceholder item={item as any} onResult={onResult} />;
   }
 
   if (type === "dragAndDropExercise") {
@@ -153,11 +150,13 @@ const NewLessonPage: React.FC = () => {
   const [step, setStep] = useState(0);
 
   const stepKeysSeen = useRef<Set<number>>(new Set());
+  const resumedRef = useRef(false);
 
   useEffect(() => {
     if (!slug) { navigate("/dashboard", { replace: true }); return; }
 
     let mounted = true;
+    resumedRef.current = false;
     void (async () => {
       try {
         setLoading(true);
@@ -177,21 +176,42 @@ const NewLessonPage: React.FC = () => {
   const rawItems: NewLessonItem[] = useMemo(() => lesson?.items ?? [], [lesson]);
   const items: NewLessonItem[] = useMemo(() => expandLessonItems(rawItems), [rawItems]);
 
-  // Distractor pool for matchAudioExercise — uses expanded items so every
-  // generated phrase is available as a potential wrong-answer option.
-  const allMatchAudioItems = useMemo(
-    () => items.filter((it) => it.type === "matchAudioExercise") as any[],
-    [items]
-  );
+  // Resume at the last-seen exercise (by content key, since the expansion
+  // above re-shuffles order every visit — a raw saved index could point at a
+  // different exercise). Runs once per lesson load.
+  useEffect(() => {
+    if (!slug || !items.length || !isAuthed() || resumedRef.current) return;
+    resumedRef.current = true;
+    let cancelled = false;
+    void (async () => {
+      const saved = await getProgress(slug);
+      if (cancelled || !saved || saved.status !== "in_progress") return;
+      const idx = saved.stepKey ? items.findIndex((it) => stepKeyForItem(it) === saved.stepKey) : -1;
+      if (idx >= 0) setStep(idx);
+      else if (saved.lastStep > 0 && saved.lastStep < items.length) setStep(saved.lastStep);
+    })();
+    return () => { cancelled = true; };
+  }, [slug, items]);
+
   const totalSteps = items.length;
   const pct = totalSteps ? Math.round(((step + 1) / totalSteps) * 100) : 0;
   const isLast = step >= totalSteps - 1;
   const activeItem = items[step];
-  const activeType = activeItem?.type as string ?? "";
-  const lessonTitle = lesson?.lesson ?? "Lesson";
+  const lessonTitle = lesson?.cardTitle || lesson?.lesson || "Lesson";
 
   const handleNext = () => {
-    if (isLast) { navigate("/dashboard"); return; }
+    if (isLast) {
+      if (slug && isAuthed() && activeItem) {
+        void upsertProgress({
+          lessonId: slug,
+          status: "completed",
+          lastStep: step,
+          stepKey: stepKeyForItem(activeItem),
+        }).catch((e) => console.error("[Progress] complete failed:", e));
+      }
+      navigate("/new-lessons");
+      return;
+    }
     setStep((s) => s + 1);
   };
 
@@ -202,6 +222,18 @@ const NewLessonPage: React.FC = () => {
   };
 
   const handleBack = () => setStep((s) => Math.max(0, s - 1));
+
+  const handleSaveAndExit = () => {
+    if (slug && isAuthed() && activeItem) {
+      void upsertProgress({
+        lessonId: slug,
+        status: "in_progress",
+        lastStep: step,
+        stepKey: stepKeyForItem(activeItem),
+      }).catch((e) => console.error("[Progress] save failed:", e));
+    }
+    navigate("/new-lessons");
+  };
 
   // ── Loading ──────────────────────────────────────────────────────────────
   if (loading) {
@@ -263,20 +295,13 @@ const NewLessonPage: React.FC = () => {
               >
                 {lessonTitle}
               </Typography>
-              <Stack direction="row" alignItems="center" gap={0.75} sx={{ mt: 0.25 }}>
-                <Chip
-                  size="small"
-                  label={`${stepIconFromType(activeType)} ${stepLabelFromType(activeType)} · ${step + 1}/${totalSteps}`}
-                  sx={{ fontWeight: 700, fontSize: "0.72rem", height: 22 }}
-                />
-              </Stack>
             </Box>
 
             <Button
               startIcon={<LogoutRoundedIcon />}
               variant="contained"
               size="small"
-              onClick={() => navigate("/new-lessons")}
+              onClick={handleSaveAndExit}
               sx={{
                 bgcolor: "#B43D20",
                 "&:hover": { bgcolor: "#9D351C" },
@@ -305,7 +330,7 @@ const NewLessonPage: React.FC = () => {
       </Box>
 
       {/* ── Content card (fills remaining height, scrolls only if needed) ─── */}
-      <Box sx={{ flex: 1, overflow: "auto", display: "flex", flexDirection: "column" }}>
+      <Box sx={{ flex: 1, overflowY: "auto", overflowX: "hidden", display: "flex", flexDirection: "column" }}>
         <Container maxWidth="md" sx={{ pt: { xs: 1.5, md: 2 }, pb: { xs: 1.5, md: 2 }, flex: 1, display: "flex", flexDirection: "column" }}>
           <Paper
             elevation={0}
@@ -324,7 +349,8 @@ const NewLessonPage: React.FC = () => {
             <Box
               sx={{
                 flex: 1,
-                overflow: "auto",
+                overflowY: "auto",
+                overflowX: "hidden",
                 px: { xs: 1.5, md: 3 },
                 py: { xs: 2, md: 2.5 },
                 display: "flex",
@@ -334,7 +360,7 @@ const NewLessonPage: React.FC = () => {
             >
               {activeItem && (
                 <Box key={`step-${step}`} sx={{ width: "100%" }}>
-                  {renderItem(activeItem, handleResult, allMatchAudioItems)}
+                  {renderItem(activeItem, handleResult)}
                 </Box>
               )}
             </Box>

--- a/client/src/pages/NewLessonsListPage.tsx
+++ b/client/src/pages/NewLessonsListPage.tsx
@@ -10,6 +10,7 @@ type Version = {
   lesson: number;
   version: number;
   to: string;
+  cardTitle?: string;
 };
 
 // Sections are always shown for at least these lesson numbers.
@@ -80,7 +81,7 @@ const VersionCard: React.FC<{ v: Version; variant: "primary" | "outlined" }> = (
   return (
     <Paper component={Link} to={v.to} elevation={0} sx={sx}>
       <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>
-        Lesson {v.lesson}.{v.version}
+        {v.cardTitle || `Lesson ${v.lesson}.${v.version}`}
       </Typography>
       {/* Reserved space for a future caption/description. */}
       <Typography sx={{ fontSize: "0.78rem", fontStyle: "italic", color: captionColor, mt: 0.5 }}>
@@ -145,14 +146,14 @@ const NewLessonsListPage: React.FC = () => {
       const grammarMap = new Map<number, Version[]>();
       for (const l of newLessons) {
         const p = parseSlug(l.slug);
-        if (p) pushVersion(grammarMap, p.lesson, { lesson: p.lesson, version: p.version, to: `/newlesson/${l.slug}` });
+        if (p) pushVersion(grammarMap, p.lesson, { lesson: p.lesson, version: p.version, to: `/newlesson/${l.slug}`, cardTitle: l.cardTitle });
       }
 
       // Reading & Writing column ← prefecture lessons (slug like "hiragana-l1-v2-hokkaido").
       const readingMap = new Map<number, Version[]>();
       for (const l of prefLessons) {
         const p = parseSlug(l.slug);
-        if (p) pushVersion(readingMap, p.lesson, { lesson: p.lesson, version: p.version, to: `/lesson/${l.slug}` });
+        if (p) pushVersion(readingMap, p.lesson, { lesson: p.lesson, version: p.version, to: `/lesson/${l.slug}`, cardTitle: l.cardTitle });
       }
 
       setGrammar(grammarMap);

--- a/client/src/pages/NewLessonsListPage.tsx
+++ b/client/src/pages/NewLessonsListPage.tsx
@@ -72,20 +72,26 @@ const Placeholder: React.FC = () => (
   </Box>
 );
 
-// A single version rendered as a card: title up top, with reserved space
-// below for a caption to be filled in later.
+// A single version rendered as a card: the big editable title up top (from
+// MongoDB's cardTitle field, with a placeholder until one is set), and the
+// auto-numbered "Lesson N.M" shown as the caption underneath.
 const VersionCard: React.FC<{ v: Version; variant: "primary" | "outlined" }> = ({ v, variant }) => {
   const sx = variant === "primary" ? primaryCard : outlinedCard;
   const captionColor = variant === "primary" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.35)";
 
   return (
     <Paper component={Link} to={v.to} elevation={0} sx={sx}>
-      <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>
-        {v.cardTitle || `Lesson ${v.lesson}.${v.version}`}
-      </Typography>
-      {/* Reserved space for a future caption/description. */}
-      <Typography sx={{ fontSize: "0.78rem", fontStyle: "italic", color: captionColor, mt: 0.5 }}>
-        Add a caption
+      {v.cardTitle ? (
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>
+          {v.cardTitle}
+        </Typography>
+      ) : (
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", fontStyle: "italic", color: captionColor }}>
+          Add a title
+        </Typography>
+      )}
+      <Typography sx={{ fontSize: "0.78rem", color: captionColor, mt: 0.5 }}>
+        Lesson {v.lesson}.{v.version}
       </Typography>
     </Paper>
   );
@@ -176,7 +182,7 @@ const NewLessonsListPage: React.FC = () => {
           <Typography
             sx={{ fontWeight: 900, fontSize: { xs: "1.6rem", sm: "2rem" }, letterSpacing: "-0.02em", color: "#1C1917" }}
           >
-            Lessons ✨
+            Lessons
           </Typography>
           <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
             Select a lesson to begin

--- a/client/src/services/lessons.ts
+++ b/client/src/services/lessons.ts
@@ -30,6 +30,7 @@ export type LessonDoc = {
   slug: string;
   title: string;
   version: string;
+  cardTitle?: string; // editable heading shown on the Lessons list card
 
   flashcards: string[];
   funFact?: string;
@@ -45,7 +46,7 @@ export type LessonDoc = {
 
 export type LessonListItem = Pick<
   LessonDoc,
-  "_id" | "slug" | "title" | "version" | "flashcards" | "prefecture" | "isActive"
+  "_id" | "slug" | "title" | "version" | "cardTitle" | "flashcards" | "prefecture" | "isActive"
 >;
 
 const BASE = "/api/lessons";

--- a/client/src/services/newLessons.ts
+++ b/client/src/services/newLessons.ts
@@ -15,6 +15,7 @@ export type NewLessonListItem = {
   _id: string;
   lesson: string; // title string, e.g. "Lesson 1 V1"
   slug: string;
+  cardTitle?: string; // editable heading shown on the Lessons list card
   isActive?: boolean;
   tags?: string[];
 };

--- a/client/src/services/progress.ts
+++ b/client/src/services/progress.ts
@@ -9,6 +9,7 @@ export type ProgressDoc = {
   lessonId: string;
   status: ProgressStatus;
   lastStep: number;
+  stepKey?: string;
   accuracyPct?: number;
   createdAt?: string;
   updatedAt?: string;
@@ -29,12 +30,29 @@ export async function upsertProgress(payload: {
   lessonId: string;
   status: ProgressStatus;
   lastStep: number;
+  stepKey?: string;
   accuracyPct?: number;
 }): Promise<ProgressDoc> {
   return json<ProgressDoc>("/api/progress", {
     method: "POST",
     data: payload,
   });
+}
+
+/**
+ * Fetch the current user's saved progress for one specific lesson (by
+ * slug). Returns null if they haven't started it, or if unauthenticated /
+ * the request fails — callers should treat that as "start from the top".
+ */
+export async function getProgress(lessonId: string): Promise<ProgressDoc | null> {
+  try {
+    const data = await json<{ progress: ProgressDoc | null }>(
+      `/api/progress/${encodeURIComponent(lessonId)}`
+    );
+    return data?.progress ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function submitAttempt(payload: {

--- a/client/src/utils/expandLessonItems.ts
+++ b/client/src/utils/expandLessonItems.ts
@@ -35,18 +35,36 @@ function isPlaceholderItem(item: NewLessonItem): boolean {
   );
 }
 
+// A term available as a multiple-choice image option — the phrase plus
+// whatever image is already associated with it elsewhere in the lesson.
+export type ChoiceCandidate = { phrase: string; imageUrl?: string };
+
+function buildCheckpointPool(terms: string[], registry: TermMediaRegistry): ChoiceCandidate[] {
+  return terms.map((phrase) => ({ phrase, imageUrl: resolveTermMedia(registry, phrase)?.imageUrl }));
+}
+
 // ── Generators ────────────────────────────────────────────────────────────────
 // Each generator looks up the term's real media (already entered somewhere
 // else in the lesson — a page, a matchingExercise dot, etc.) before falling
 // back to a placeholder, so re-entering it in MongoDB Compass isn't needed.
 
-function makeMatchAudio(phrase: string, number: number, registry: TermMediaRegistry): NewLessonItem {
+function makeMatchAudio(
+  phrase: string,
+  number: number,
+  registry: TermMediaRegistry,
+  checkpointPool: ChoiceCandidate[]
+): NewLessonItem {
   const media = resolveTermMedia(registry, phrase);
   return {
     type: "matchAudioExercise",
     number,
     phrase,
     audioUrl: media?.audioUrl ?? "PLACEHOLDER_AUDIO_URL",
+    imageUrl: media?.imageUrl,
+    // Other terms learned since the last checkpoint (or since the start of
+    // the lesson, for the first checkpoint) — the distractor pool for the
+    // multiple-choice image UI. See MatchAudioExercisePlaceholder.
+    checkpointPool,
   } as unknown as NewLessonItem;
 }
 
@@ -101,6 +119,7 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
 
   const result: NewLessonItem[] = [];
   let currentTerms: string[] = [];
+  let currentPool: ChoiceCandidate[] = [];
   let i = 0;
 
   while (i < items.length) {
@@ -111,6 +130,7 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
     if (type === "matchingExercise") {
       const matchItems: Array<{ phrase?: string }> = (item as any).items ?? [];
       currentTerms = shuffled(matchItems.map((m) => String(m.phrase ?? "")));
+      currentPool = buildCheckpointPool(currentTerms, registry);
       result.push(enrichItemWithTermMedia(item, registry));
       i++;
       continue;
@@ -135,11 +155,13 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
         i++;
       }
 
-      // Emit one generated item per term
+      // Emit one generated item per term. Snapshot currentPool into a const
+      // so the closure below doesn't reference the outer `let` directly.
+      const poolForThisBlock = currentPool;
       currentTerms.forEach((phrase, idx) => {
         const num = idx + 1;
         if (type === "matchAudioExercise") {
-          result.push(makeMatchAudio(phrase, num, registry));
+          result.push(makeMatchAudio(phrase, num, registry, poolForThisBlock));
         } else if (type === "pronunciationExercise") {
           result.push(makePronunciation(phrase, num, registry));
         } else {
@@ -151,7 +173,12 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
 
     // ── Pass through, filling in any media already associated with this
     // item's term elsewhere in the lesson ────────────────────────────────────
-    result.push(enrichItemWithTermMedia(item, registry));
+    const enriched = enrichItemWithTermMedia(item, registry);
+    if (type === "matchAudioExercise") {
+      const any = enriched as any;
+      any.checkpointPool = currentPool.length ? currentPool : [{ phrase: any.phrase, imageUrl: any.imageUrl }];
+    }
+    result.push(enriched);
     i++;
   }
 

--- a/client/src/utils/expandLessonItems.ts
+++ b/client/src/utils/expandLessonItems.ts
@@ -1,4 +1,10 @@
 import { NewLessonItem } from "../services/newLessons";
+import {
+  buildTermMediaRegistry,
+  enrichItemWithTermMedia,
+  resolveTermMedia,
+  TermMediaRegistry,
+} from "./termMedia";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -30,30 +36,43 @@ function isPlaceholderItem(item: NewLessonItem): boolean {
 }
 
 // ── Generators ────────────────────────────────────────────────────────────────
+// Each generator looks up the term's real media (already entered somewhere
+// else in the lesson — a page, a matchingExercise dot, etc.) before falling
+// back to a placeholder, so re-entering it in MongoDB Compass isn't needed.
 
-function makeMatchAudio(phrase: string, number: number): NewLessonItem {
+function makeMatchAudio(phrase: string, number: number, registry: TermMediaRegistry): NewLessonItem {
+  const media = resolveTermMedia(registry, phrase);
   return {
     type: "matchAudioExercise",
     number,
     phrase,
-    audioUrl: "PLACEHOLDER_AUDIO_URL",
+    audioUrl: media?.audioUrl ?? "PLACEHOLDER_AUDIO_URL",
   } as unknown as NewLessonItem;
 }
 
-function makePronunciation(phrase: string, number: number): NewLessonItem {
+function makePronunciation(phrase: string, number: number, registry: TermMediaRegistry): NewLessonItem {
+  const media = resolveTermMedia(registry, phrase);
   return {
     type: "pronunciationExercise",
     number,
     phrase,
-    audioUrl: "PLACEHOLDER_AUDIO_URL",
+    audioUrl: media?.audioUrl ?? "PLACEHOLDER_AUDIO_URL",
   } as unknown as NewLessonItem;
 }
 
-function makeDragDrop(templateItem: NewLessonItem, phrase: string, number: number): NewLessonItem {
+function makeDragDrop(
+  templateItem: NewLessonItem,
+  phrase: string,
+  number: number,
+  registry: TermMediaRegistry
+): NewLessonItem {
+  const media = resolveTermMedia(registry, phrase);
   return {
     ...(templateItem as object),
     _term: phrase,
     number,
+    audioUrl: media?.audioUrl,
+    imageUrl: media?.imageUrl,
   } as unknown as NewLessonItem;
 }
 
@@ -74,6 +93,12 @@ function makeDragDrop(templateItem: NewLessonItem, phrase: string, number: numbe
  * - Items before the first matchingExercise are always passed through.
  */
 export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
+  // Built once from the raw, un-expanded items so media entered anywhere in
+  // the lesson (a page's video/audio, a hand-authored matching-exercise dot,
+  // etc.) is available to every other item that references the same term —
+  // regardless of which one appears first.
+  const registry = buildTermMediaRegistry(items);
+
   const result: NewLessonItem[] = [];
   let currentTerms: string[] = [];
   let i = 0;
@@ -86,7 +111,7 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
     if (type === "matchingExercise") {
       const matchItems: Array<{ phrase?: string }> = (item as any).items ?? [];
       currentTerms = shuffled(matchItems.map((m) => String(m.phrase ?? "")));
-      result.push(item);
+      result.push(enrichItemWithTermMedia(item, registry));
       i++;
       continue;
     }
@@ -114,18 +139,19 @@ export function expandLessonItems(items: NewLessonItem[]): NewLessonItem[] {
       currentTerms.forEach((phrase, idx) => {
         const num = idx + 1;
         if (type === "matchAudioExercise") {
-          result.push(makeMatchAudio(phrase, num));
+          result.push(makeMatchAudio(phrase, num, registry));
         } else if (type === "pronunciationExercise") {
-          result.push(makePronunciation(phrase, num));
+          result.push(makePronunciation(phrase, num, registry));
         } else {
-          result.push(makeDragDrop(templateItem, phrase, num));
+          result.push(makeDragDrop(templateItem, phrase, num, registry));
         }
       });
       continue;
     }
 
-    // ── Pass through unchanged ───────────────────────────────────────────────
-    result.push(item);
+    // ── Pass through, filling in any media already associated with this
+    // item's term elsewhere in the lesson ────────────────────────────────────
+    result.push(enrichItemWithTermMedia(item, registry));
     i++;
   }
 

--- a/client/src/utils/termMedia.ts
+++ b/client/src/utils/termMedia.ts
@@ -1,0 +1,227 @@
+import { NewLessonItem } from "../services/newLessons";
+
+// Shared media a term can carry — the same term (e.g. "Hajimemashite") may
+// need its audio in a matchAudioExercise, its image in a matchingExercise,
+// and its video in a page's "New terms" list.
+export type TermMedia = {
+  audioUrl?: string;
+  videoUrl?: string;
+  imageUrl?: string;
+};
+
+const MEDIA_KEYS: Array<keyof TermMedia> = ["audioUrl", "videoUrl", "imageUrl"];
+
+export function isPlaceholderUrl(url?: unknown): boolean {
+  if (typeof url !== "string" || !url) return true;
+  return url.toUpperCase().includes("PLACEHOLDER");
+}
+
+function pickReal(url?: unknown): string | undefined {
+  return typeof url === "string" && url && !isPlaceholderUrl(url) ? url : undefined;
+}
+
+// Case/punctuation-insensitive key so authored variants of the same term
+// (e.g. "~ desu ka" vs "~desu ka.") resolve to the same registry entry.
+function exactKey(term: string): string {
+  return term.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// Looser fallback key that also collapses runs of the same letter, so typo'd
+// duplicates entered separately in MongoDB (e.g. "Konnnichiwa" vs
+// "Konnichiwa", "Sumimasenn" vs "Sumimasen") still resolve to one term.
+function fuzzyKey(term: string): string {
+  return exactKey(term).replace(/(.)\1+/g, "$1");
+}
+
+function mergeMedia(base: TermMedia, extra: TermMedia): TermMedia {
+  const merged: TermMedia = { ...base };
+  for (const key of MEDIA_KEYS) {
+    if (!merged[key] && extra[key]) merged[key] = extra[key];
+  }
+  return merged;
+}
+
+/**
+ * Every (term, media) pair a single lesson item can contribute. An item may
+ * introduce more than one term — a page contributes its own title plus each
+ * of its `newTerms`/`terms`; a matchingExercise contributes one term per dot.
+ */
+function extractEntries(item: NewLessonItem): Array<{ term: string; media: TermMedia }> {
+  const type = item.type as string;
+  const any = item as any;
+  const entries: Array<{ term: string; media: TermMedia }> = [];
+
+  if (type === "page") {
+    if (any.title) {
+      entries.push({
+        term: String(any.title),
+        media: {
+          audioUrl: any.audioUrl ?? any.audioURL ?? any.audio,
+          videoUrl: any.videoUrl ?? any.videoURL ?? any.video,
+        },
+      });
+    }
+    if (Array.isArray(any.newTerms)) {
+      for (const t of any.newTerms) {
+        if (!t || typeof t !== "object") continue;
+        const term = t.term ?? t.word ?? t.text ?? t.Title ?? t.title;
+        if (!term) continue;
+        entries.push({
+          term: String(term),
+          media: { audioUrl: t.audioUrl ?? t.audio, videoUrl: t.videoUrl ?? t.video, imageUrl: t.imageUrl ?? t.image },
+        });
+      }
+    }
+    if (Array.isArray(any.terms)) {
+      for (const t of any.terms) {
+        if (!t || typeof t !== "object" || !t.term) continue;
+        entries.push({
+          term: String(t.term),
+          media: { audioUrl: t.audioUrl, videoUrl: t.videoUrl, imageUrl: t.imageUrl },
+        });
+      }
+    }
+  }
+
+  if (type === "matchingExercise" && Array.isArray(any.items)) {
+    for (const m of any.items) {
+      if (!m?.phrase) continue;
+      entries.push({ term: String(m.phrase), media: { audioUrl: m.audioUrl, imageUrl: m.imageUrl } });
+    }
+  }
+
+  if ((type === "matchAudioExercise" || type === "pronunciationExercise") && any.phrase) {
+    entries.push({ term: String(any.phrase), media: { audioUrl: any.audioUrl } });
+  }
+
+  if (type === "dragAndDropExercise") {
+    const term = any.phrase ?? any._term ?? any.term;
+    if (term) {
+      entries.push({ term: String(term), media: { audioUrl: any.audioUrl, imageUrl: any.imageUrl ?? any.image } });
+    }
+  }
+
+  return entries;
+}
+
+export type TermMediaRegistry = {
+  exact: Map<string, TermMedia>;
+  fuzzy: Map<string, TermMedia>;
+};
+
+/**
+ * Scans every item in a lesson (in any order) and collects the real,
+ * non-placeholder media already associated with each term, so it can be
+ * reused wherever else that term appears.
+ */
+export function buildTermMediaRegistry(items: NewLessonItem[]): TermMediaRegistry {
+  const exact = new Map<string, TermMedia>();
+  const fuzzy = new Map<string, TermMedia>();
+
+  for (const item of items) {
+    for (const { term, media } of extractEntries(item)) {
+      const realMedia: TermMedia = {
+        audioUrl: pickReal(media.audioUrl),
+        videoUrl: pickReal(media.videoUrl),
+        imageUrl: pickReal(media.imageUrl),
+      };
+      if (!realMedia.audioUrl && !realMedia.videoUrl && !realMedia.imageUrl) continue;
+
+      const ek = exactKey(term);
+      const fk = fuzzyKey(term);
+      if (ek) exact.set(ek, mergeMedia(exact.get(ek) ?? {}, realMedia));
+      if (fk) fuzzy.set(fk, mergeMedia(fuzzy.get(fk) ?? {}, realMedia));
+    }
+  }
+
+  return { exact, fuzzy };
+}
+
+export function resolveTermMedia(registry: TermMediaRegistry, term?: string): TermMedia | undefined {
+  if (!term) return undefined;
+  const ek = exactKey(term);
+  if (ek && registry.exact.has(ek)) return registry.exact.get(ek);
+  const fk = fuzzyKey(term);
+  if (fk && registry.fuzzy.has(fk)) return registry.fuzzy.get(fk);
+  return undefined;
+}
+
+/**
+ * Fills placeholder/missing audio, video, and image fields on an item using
+ * media already associated with the same term elsewhere in the lesson.
+ * Never overwrites real media the item already carries. Returns a new item
+ * (or the original reference when nothing changed) — the input is untouched.
+ */
+export function enrichItemWithTermMedia(item: NewLessonItem, registry: TermMediaRegistry): NewLessonItem {
+  const type = item.type as string;
+  const any = item as any;
+
+  if (type === "page") {
+    const title = any.title as string | undefined;
+    const resolved = resolveTermMedia(registry, title);
+    const next: any = { ...any };
+    if (!pickReal(any.audioUrl) && !pickReal(any.audioURL) && !pickReal(any.audio) && resolved?.audioUrl) {
+      next.audioUrl = resolved.audioUrl;
+    }
+    if (!pickReal(any.videoUrl) && !pickReal(any.videoURL) && !pickReal(any.video) && resolved?.videoUrl) {
+      next.videoUrl = resolved.videoUrl;
+    }
+    if (Array.isArray(any.newTerms)) {
+      next.newTerms = any.newTerms.map((t: any) => {
+        if (!t || typeof t !== "object") return t;
+        const term = t.term ?? t.word ?? t.text ?? t.Title ?? t.title;
+        const r = resolveTermMedia(registry, term);
+        return {
+          ...t,
+          audioUrl: pickReal(t.audioUrl ?? t.audio) ?? r?.audioUrl ?? t.audioUrl,
+          videoUrl: pickReal(t.videoUrl ?? t.video) ?? r?.videoUrl ?? t.videoUrl,
+        };
+      });
+    }
+    if (Array.isArray(any.terms)) {
+      next.terms = any.terms.map((t: any) => {
+        if (!t || typeof t !== "object" || !t.term) return t;
+        const r = resolveTermMedia(registry, t.term);
+        return {
+          ...t,
+          audioUrl: pickReal(t.audioUrl) ?? r?.audioUrl ?? t.audioUrl,
+          videoUrl: pickReal(t.videoUrl) ?? r?.videoUrl ?? t.videoUrl,
+          imageUrl: pickReal(t.imageUrl) ?? r?.imageUrl ?? t.imageUrl,
+        };
+      });
+    }
+    return next;
+  }
+
+  if (type === "matchingExercise" && Array.isArray(any.items)) {
+    return {
+      ...any,
+      items: any.items.map((m: any) => {
+        const r = resolveTermMedia(registry, m?.phrase);
+        return {
+          ...m,
+          audioUrl: pickReal(m?.audioUrl) ?? r?.audioUrl ?? m?.audioUrl,
+          imageUrl: pickReal(m?.imageUrl) ?? r?.imageUrl ?? m?.imageUrl,
+        };
+      }),
+    };
+  }
+
+  if ((type === "matchAudioExercise" || type === "pronunciationExercise") && any.phrase) {
+    const r = resolveTermMedia(registry, any.phrase);
+    return { ...any, audioUrl: pickReal(any.audioUrl) ?? r?.audioUrl ?? any.audioUrl };
+  }
+
+  if (type === "dragAndDropExercise") {
+    const term = any.phrase ?? any._term ?? any.term;
+    if (!term) return item;
+    const r = resolveTermMedia(registry, term);
+    return {
+      ...any,
+      audioUrl: pickReal(any.audioUrl) ?? r?.audioUrl ?? any.audioUrl,
+      imageUrl: pickReal(any.imageUrl ?? any.image) ?? r?.imageUrl ?? any.imageUrl,
+    };
+  }
+
+  return item;
+}

--- a/client/src/utils/termMedia.ts
+++ b/client/src/utils/termMedia.ts
@@ -209,7 +209,11 @@ export function enrichItemWithTermMedia(item: NewLessonItem, registry: TermMedia
 
   if ((type === "matchAudioExercise" || type === "pronunciationExercise") && any.phrase) {
     const r = resolveTermMedia(registry, any.phrase);
-    return { ...any, audioUrl: pickReal(any.audioUrl) ?? r?.audioUrl ?? any.audioUrl };
+    const next: any = { ...any, audioUrl: pickReal(any.audioUrl) ?? r?.audioUrl ?? any.audioUrl };
+    if (type === "matchAudioExercise") {
+      next.imageUrl = pickReal(any.imageUrl) ?? r?.imageUrl ?? any.imageUrl;
+    }
+    return next;
   }
 
   if (type === "dragAndDropExercise") {

--- a/server/src/controllers/lessonController.ts
+++ b/server/src/controllers/lessonController.ts
@@ -21,7 +21,7 @@ export const listLessons: RequestHandler = (req, res) => {
       if (prefecture) query.prefecture = prefecture;
 
       const lessons = await Lesson.find(query)
-        .select("slug title version flashcards prefecture isActive")
+        .select("slug title version cardTitle flashcards prefecture isActive")
         .sort({ createdAt: 1 })
         .lean();
 

--- a/server/src/controllers/newLessonController.ts
+++ b/server/src/controllers/newLessonController.ts
@@ -10,7 +10,7 @@ export const listNewLessons: RequestHandler = (req, res) => {
   void (async (): Promise<void> => {
     try {
       const newLessons = await NewLesson.find({ isActive: { $ne: false } })
-        .select("lesson slug isActive tags createdAt")
+        .select("lesson slug cardTitle isActive tags createdAt")
         .sort({ createdAt: 1 })
         .lean();
 

--- a/server/src/controllers/progressController.ts
+++ b/server/src/controllers/progressController.ts
@@ -18,11 +18,12 @@ export const upsertProgress: RequestHandler = async (req, res): Promise<void> =>
       return;
     }
 
-    const { lessonId, status, lastStep, accuracyPct } = (req.body || {}) as {
+    const { lessonId, status, lastStep, accuracyPct, stepKey } = (req.body || {}) as {
       lessonId: string;
       status: "in_progress" | "completed";
       lastStep: number;
       accuracyPct?: number;
+      stepKey?: string;
     };
 
     if (
@@ -46,6 +47,7 @@ export const upsertProgress: RequestHandler = async (req, res): Promise<void> =>
         status,
         lastStep,
         accuracyPct: accuracyPct ?? 0,
+        stepKey: stepKey ?? "",
         updatedAt: new Date(),
       },
       { new: true, upsert: true, setDefaultsOnInsert: true }
@@ -162,6 +164,41 @@ export const getUpNextLesson: RequestHandler = async (req, res): Promise<void> =
     return;
   } catch (err: any) {
     console.error(`[PROGRESS][${rid}] up-next error`, err?.message || err);
+    res.status(500).json({ error: "Internal error", details: err?.message || String(err) });
+    return;
+  }
+};
+
+/**
+ * GET /api/progress/:lessonId
+ * Returns the current user's saved progress for one specific lesson (by
+ * slug), or { progress: null } if they haven't started it — used to resume
+ * a lesson at the exercise the user last saw.
+ */
+export const getProgressForLesson: RequestHandler = async (req, res): Promise<void> => {
+  const rid = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const authed = req as AuthedRequest;
+    const userId = authed.user?._id;
+
+    if (!userId) {
+      console.warn(`[PROGRESS][${rid}] get-by-lesson unauthorized: missing req.user`);
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const { lessonId } = req.params;
+    if (!lessonId) {
+      res.status(400).json({ error: "lessonId is required" });
+      return;
+    }
+
+    const doc = await UserProgress.findOne({ userId, lessonId }).lean();
+    res.status(200).json({ progress: doc ?? null });
+    return;
+  } catch (err: any) {
+    console.error(`[PROGRESS][${rid}] get-by-lesson error`, err?.message || err);
     res.status(500).json({ error: "Internal error", details: err?.message || String(err) });
     return;
   }

--- a/server/src/models/Lesson.ts
+++ b/server/src/models/Lesson.ts
@@ -49,6 +49,10 @@ const LessonSchema = new Schema(
     title: { type: String, required: true },
     version: { type: String, default: "V1" },
 
+    // Editable heading shown on the Lessons list card. Falls back to the
+    // auto-computed "Lesson {n}.{m}" (derived from slug) when left blank.
+    cardTitle: { type: String, default: "", trim: true },
+
     flashcards: { type: [String], default: [] },
     funFact: { type: String, default: "" },
     notes: { type: String, default: "" },

--- a/server/src/models/NewLesson.ts
+++ b/server/src/models/NewLesson.ts
@@ -12,10 +12,10 @@ const NewLessonSchema = new Schema(
     // Divergence from lessons: lessons uses "title"; newlessons uses "lesson".
     // Flag: when merging the two collections, normalise to "title" on both sides.
     lesson: { type: String, required: true },
-    slug: { type: String, required: true, unique: true, index: true },
     // Editable heading shown on the Lessons list card. Falls back to the
     // auto-computed "Lesson {n}.{m}" (derived from slug) when left blank.
     cardTitle: { type: String, default: "", trim: true },
+    slug: { type: String, required: true, unique: true, index: true },
     items: { type: [NewLessonItemSchema], default: [] },
     isActive: { type: Boolean, default: true },
     tags: { type: [String], default: [] },

--- a/server/src/models/NewLesson.ts
+++ b/server/src/models/NewLesson.ts
@@ -13,6 +13,9 @@ const NewLessonSchema = new Schema(
     // Flag: when merging the two collections, normalise to "title" on both sides.
     lesson: { type: String, required: true },
     slug: { type: String, required: true, unique: true, index: true },
+    // Editable heading shown on the Lessons list card. Falls back to the
+    // auto-computed "Lesson {n}.{m}" (derived from slug) when left blank.
+    cardTitle: { type: String, default: "", trim: true },
     items: { type: [NewLessonItemSchema], default: [] },
     isActive: { type: Boolean, default: true },
     tags: { type: [String], default: [] },

--- a/server/src/models/UserProgress.ts
+++ b/server/src/models/UserProgress.ts
@@ -27,6 +27,14 @@ const UserProgressSchema = new Schema(
       default: 0,
       min: 0,
     },
+    // Content-derived key identifying the exact exercise lastStep pointed to.
+    // Grammar lessons re-shuffle exercise order on every visit, so the raw
+    // index alone isn't enough to resume the same exercise — this key lets
+    // the client find it again in a freshly-shuffled list.
+    stepKey: {
+      type: String,
+      default: "",
+    },
     accuracyPct: {
       type: Number,
       default: 0,

--- a/server/src/routes/progressRoutes.ts
+++ b/server/src/routes/progressRoutes.ts
@@ -4,6 +4,7 @@ import {
   upsertProgress,
   getProgressSummary,
   getUpNextLesson,
+  getProgressForLesson,
 } from "../controllers/progressController";
 import { requireAuth } from "../middleware/requireAuth";
 
@@ -12,5 +13,8 @@ const router = Router();
 router.post("/", requireAuth, upsertProgress);
 router.get("/summary", requireAuth, getProgressSummary);
 router.get("/up-next", requireAuth, getUpNextLesson);
+// Must come after the literal routes above — "/:lessonId" would otherwise
+// swallow "/summary" and "/up-next".
+router.get("/:lessonId", requireAuth, getProgressForLesson);
 
 export default router;


### PR DESCRIPTION
## Summary

- New **Grammar lesson flow**: `newlessons` backend + `NewLessonPage`, rendering dialogue pages, matching exercises, audio-match, drag-and-drop, pronunciation practice, and flashcard review from a single schemaless lesson document.
- Redesigned the Lessons list into **Grammar / Reading & Writing columns**, with a per-lesson `cardTitle` field editable directly in MongoDB (falls back to the auto-numbered "Lesson N.M" heading when unset).
- **Save & resume**: lessons now persist and restore the last-seen exercise per user (new `GET /api/progress/:lessonId` endpoint + a content-derived `stepKey`, since Grammar lessons reshuffle exercise order on every visit and a raw index alone can't reliably resume the same exercise). Wired into both the Grammar and Reading & Writing flows; Finish/Save & Exit/Back now consistently return to `/new-lessons`.
- **Deduped multiple-choice exercises** — `matchAudioExercise` and `matchAudioLetter` no longer pad with a duplicate of the correct answer (or show a repeated distractor) when the term pool is small; they now simply show fewer options instead of ever repeating one.
- Added the **forgot-password page** with direct email-based reset.
- Misc UI polish: pronunciation buttons on dialogue pages, removed horizontal scroll on the matching-exercise (dots) components, removed the exercise-type/step-count subtitle chip, removed the stray star emoji on the Lessons page title.

## Test plan

- [ ] Manual QA: log in, walk a Grammar lesson end-to-end (pages, matching, audio-match, pronunciation, drag & drop)
- [ ] Manual QA: walk a Reading & Writing lesson end-to-end
- [ ] Verify Save & Exit resumes at the correct exercise for both flows, including after a Grammar lesson's exercises re-shuffle
- [ ] Verify the forgot-password reset flow sends/handles the reset email correctly
- [ ] `tsc --noEmit` passes on both `client` and `server` (verified locally throughout this branch)

## Reviewer notes

- `client/src/pages/Dashboard.tsx` has debug instrumentation blocks (`#region agent log`) that POST to `http://127.0.0.1:7898/ingest/...` on lesson load / prefecture click / pin click — looks like leftover local debugging telemetry, worth stripping before this reaches production.
- `server/scripts/seedLesson.ts` is stale — it seeds the old `Lesson` shape (`kind`/`steps`) that no longer matches either current schema, so it'll silently produce broken data if run today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
