### PR TITLE
Payload Live Preview, and close the public draft leak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,25 @@ PAYLOAD_SECRET=
 # Payload's auth-gated /api/media/file/... route, never from a raw blob URL.
 BLOB_READ_WRITE_TOKEN=
 
+# Required for CMS Live Preview. Generate with: openssl rand -hex 32
+#
+# /api/preview refuses every request when this is unset, and the admin hides
+# Live Preview rather than offering a panel that 403s — so leaving it empty
+# turns the feature off cleanly instead of half-on. It is not the security
+# boundary on its own: Payload puts this value in the preview iframe's src
+# where any signed-in editor can read it, so the route also checks the caller's
+# `cms_admins` session.
+PREVIEW_SECRET=
+
+# Public origin of the app. Used to build the Live Preview iframe URL, and it
+# is the origin the front end checks incoming preview messages against — so it
+# must be the exact origin /admin is served from, scheme and port included.
+#
+# Unlike BETTER_AUTH_URL, set this on *every* environment, each to its own URL.
+# It falls back to http://localhost:3000, which is wrong on any deploy: live
+# preview then points the iframe at the editor's own machine.
+NEXT_PUBLIC_SERVER_URL=http://localhost:3000
+
 # ── Auth ────────────────────────────────────────────────────────────────────
 # Required. Generate with: openssl rand -base64 32
 # Use a different value per environment. There is no default — the app refuses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,22 @@ the moment an editor saves. A one-hour expiry is the backstop for a missed hook.
 Reads pass `overrideAccess: false`, so an unpublished draft cannot leak even if a
 query forgets to filter. Keep new reads inside this module and inside that rule.
 
+That rule only became true once the collections' own `read` access enforced it.
+The three content collections share `readPublishedOrEditor`
+(`src/payload/access/readPublished.ts`): a signed-in CMS user reads everything,
+everyone else is constrained to `_status: published`. They previously declared
+`read: () => true`, which is not "public read" but *no filter at all* — and
+Payload's REST API is mounted publicly, so `GET /api/lessons` served unpublished
+documents to anyone, with or without `?draft=true`. Never write
+`read: () => true` on a collection that has drafts enabled.
+
+The draft readers at the bottom of that file (`getDraftLesson`,
+`getDraftNextSlug`, `getDraftResources`) are the one exception to the published
+filter, and they stay inside the rule: they are uncached, they only run for a
+request in Draft Mode, and they pass the authenticated `cms_admins` editor as
+`user` rather than switching `overrideAccess` off. They exist for the CMS
+preview panel — see `docs/payload-content-model.md`.
+
 ### Two players, one collection
 
 Lessons used to be two parallel systems. They are now one `lessons` collection with a

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Everything is documented inline in [`.env.example`](.env.example). Summary:
 | `PAYLOAD_SECRET` | the CMS | `/admin` and Payload's REST API 500 without it. Rotating it drops every admin session |
 | `BETTER_AUTH_URL` | production | Production only. Optional locally, and must stay unset on Preview — pinned to the production domain it makes previews 403 their own sign-in |
 | `BLOB_READ_WRITE_TOKEN` | CMS media | Set for you when Blob storage is added to the Vercel project. The store must be **private** — media is served through Payload's auth-gated route, so signed-out requests 403. Empty locally falls back to the filesystem |
+| `PREVIEW_SECRET` | CMS live preview | Fails closed: unset, `/api/preview` 403s everything and the admin hides Live Preview. Not the boundary on its own — the route also checks the caller's `cms_admins` session |
+| `NEXT_PUBLIC_SERVER_URL` | CMS live preview | The exact origin `/admin` is served from. Set it per environment, Preview included. Falls back to `http://localhost:3000`, which is wrong on any deploy |
 | `RESEND_API_KEY` / `EMAIL_FROM` | password reset emails | Without them, dev prints the reset link to the server console |
 | `PRONUNCIATION_SERVICE_URL` / `_SECRET` | pronunciation scoring | See `services/pronunciation/README.md` |
 | `MONGODB_URI` | migration scripts only | **Never set this on Vercel** |

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -167,6 +167,8 @@ here to skip:
 DATABASE_URL                  = set for you by the Neon integration   ← Production ONLY
 PAYLOAD_SECRET                = <openssl rand -base64 32>   ← fresh; required
 BLOB_READ_WRITE_TOKEN         = set for you when Blob storage is added
+PREVIEW_SECRET                = <openssl rand -hex 32>   ← fresh; CMS live preview
+NEXT_PUBLIC_SERVER_URL        = the deployment's own origin   ← per environment
 BETTER_AUTH_SECRET            = <openssl rand -base64 32>   ← fresh, not your local one
 BETTER_AUTH_URL               = https://<the production domain>   ← Production ONLY
 RESEND_API_KEY                = <resend key>
@@ -193,6 +195,12 @@ static Preview value silently overrides that:
   whose host is production's. If Production's is missing entirely, its checkbox is off in
   Neon → Integrations → Vercel → Settings; toggling it re-pushes the set. See
   [docs/database-workflow.md](database-workflow.md).
+
+`NEXT_PUBLIC_SERVER_URL` is the mirror image of `BETTER_AUTH_URL`: it has to be set on
+every environment, each to that deployment's own origin. It is the origin the front end
+checks Live Preview's `postMessage` against, so a Preview deployment carrying the
+production value silently drops every preview update. On Preview, set it to the stable
+`*-git-<branch>` alias rather than the per-deployment URL, which changes on every push.
 
 `PAYLOAD_SECRET` is **required — the app does not boot without it.** There is no silent
 fallback: with it unset, Payload fails to initialize, so `/admin` 500s and every page

--- a/docs/payload-content-model.md
+++ b/docs/payload-content-model.md
@@ -136,6 +136,63 @@ no longer applies to content, though the fields are still plain strings and can
 still hold an arbitrary absolute URL. Wiring components to real `upload`
 relationships is now unblocked but deliberately not done.
 
+## Live preview
+
+Open a lesson or a resource group in `/admin` and there is a **Live Preview**
+tab beside **Edit**. It renders the real front end in a panel next to the form
+and updates it *as you type* — no save, no reload. The **Preview** button next
+to Save opens the same page in its own tab instead.
+
+Only `lessons` and `resources` have it. A course is a grouping with no page of
+its own, and media is an upload; neither has anything for the panel to load.
+Lessons open in whichever player `format` selects, so flipping `format` moves
+the panel between `/lesson/<slug>` and `/newlesson/<slug>`.
+
+Two environment variables turn it on: `PREVIEW_SECRET` and
+`NEXT_PUBLIC_SERVER_URL`. Without the secret the feature hides itself rather
+than half-working. `NEXT_PUBLIC_SERVER_URL` must be the exact origin `/admin`
+is served from — it is what the front end checks incoming preview messages
+against, so a wrong value shows a panel that never updates.
+
+**How a draft reaches the page.** The panel's iframe points at `/api/preview`,
+not at the page. That route is the only thing in the app that turns Next's
+Draft Mode on, and it checks two things before it does: the `previewSecret` in
+the URL, and a live `cms_admins` session via `payload.auth()`. The secret only
+proves the link came from our admin — Payload puts it in the iframe's `src`,
+where any signed-in editor can read it — so the session check is the real
+boundary. Once Draft Mode is on, the three previewable pages read through the
+draft lookups in `src/lib/content/content.ts`, which are uncached and pass the
+authenticated editor through to Payload's access rules.
+
+**Drafts are gated at the collection, not by the app's queries.** `lessons`,
+`courses` and `resources` share `readPublishedOrEditor`
+(`src/payload/access/readPublished.ts`): signed-in CMS users read everything,
+everyone else is constrained to `_status: published`. This is what actually
+keeps unpublished work private — the public REST API at `/api/<collection>` is
+reachable by anyone, and the previous `read: () => true` applied no filter, so
+it served drafts to unauthenticated callers directly. The published filters in
+`content.ts` are now a second statement of the same rule rather than the only
+one.
+
+The same split applies to the player's own auth gate: a CMS editor has a
+`payload-token`, not a better-auth learner session, so
+`requirePlayerAccess()` in `src/lib/session.ts` admits either. `src/proxy.ts`
+lets the Draft Mode cookie past on presence alone, which is safe only because
+the layout behind it re-checks the editor on every request — the cookie is a
+build-scoped token that names nobody and outlives the session that obtained it.
+
+**Getting out.** Draft Mode is a cookie on the whole origin and it survives
+until the browser closes, so after previewing you keep seeing unpublished
+content while browsing normally. Visit **`/api/exit-preview`** to clear it.
+
+Two known edges, both harmless:
+
+- A step lesson's "next lesson" is resolved once when the preview loads. Reorder
+  the course while the panel is open and it goes stale until you save and
+  reload.
+- On `/resources`, only the group you have open updates live. The others show
+  what is currently saved, which is the honest rendering of a shared page.
+
 ## Running the tooling
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/material-nextjs": "^9.3.0",
         "@neondatabase/serverless": "^1.1.0",
         "@payloadcms/db-postgres": "3.88.0",
+        "@payloadcms/live-preview-react": "3.88.0",
         "@payloadcms/next": "3.88.0",
         "@payloadcms/plugin-cloud-storage": "3.88.0",
         "@vercel/analytics": "^2.0.1",
@@ -2728,6 +2729,25 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/@payloadcms/live-preview": {
+      "version": "3.88.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/live-preview/-/live-preview-3.88.0.tgz",
+      "integrity": "sha512-Be6bC3j1Yd+rDfjRKz2MVtfr8hJUHG+jLeRaN2yWjQRoWCxFB9srBmob8FXD7azTS73d56hrDCNyzQx5HbgK6A==",
+      "license": "MIT"
+    },
+    "node_modules/@payloadcms/live-preview-react": {
+      "version": "3.88.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/live-preview-react/-/live-preview-react-3.88.0.tgz",
+      "integrity": "sha512-Pmlo1xczmOetyyC4rhtp50b0/biYE62+w09hKImN26v8DBNCqZ8b699mknOCo60mar4V4KrlvksCpL9t2e0dHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@payloadcms/live-preview": "3.88.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.1 || ^19.1.2 || ^19.2.1",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.1 || ^19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@payloadcms/next": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@mui/material-nextjs": "^9.3.0",
     "@neondatabase/serverless": "^1.1.0",
     "@payloadcms/db-postgres": "3.88.0",
+    "@payloadcms/live-preview-react": "3.88.0",
     "@payloadcms/next": "3.88.0",
     "@payloadcms/plugin-cloud-storage": "3.88.0",
     "@vercel/analytics": "^2.0.1",

--- a/src/app/(app)/(player)/layout.tsx
+++ b/src/app/(app)/(player)/layout.tsx
@@ -1,4 +1,4 @@
-import { requireSession } from "../../../lib/session";
+import { requirePlayerAccess } from "../../../lib/session";
 
 /*
  * Lesson players render without Header or Footer — the CRA app did this with
@@ -10,6 +10,8 @@ export default async function PlayerLayout({
 }: {
   children: React.ReactNode;
 }) {
-  await requireSession();
+  // A learner's session, or a CMS editor previewing a draft — the two identity
+  // systems are separate, and an editor has no better-auth session to offer.
+  await requirePlayerAccess();
   return <>{children}</>;
 }

--- a/src/app/(app)/(player)/lesson/[lessonId]/page.tsx
+++ b/src/app/(app)/(player)/lesson/[lessonId]/page.tsx
@@ -1,6 +1,12 @@
 import { redirect } from "next/navigation";
 import LessonPlayer from "../../../../../pages-client/LessonPlayer";
-import { getLessonBySlug } from "../../../../../lib/content/content";
+import LessonPreview from "../../../../../pages-client/preview/LessonPreview";
+import {
+  DRAFT_FLASHCARD,
+  getDraftLesson,
+  getLessonBySlug,
+} from "../../../../../lib/content/content";
+import { getPreviewEditor } from "../../../../../lib/session";
 
 export default async function Page({
   params,
@@ -8,6 +14,22 @@ export default async function Page({
   params: Promise<{ lessonId: string }>;
 }) {
   const { lessonId } = await params;
+
+  // The CMS preview path — see the note in the step player's page. Only a
+  // request that came through /api/preview *and* still resolves to a
+  // `cms_admins` user gets here; everything else reads published content.
+  const editor = await getPreviewEditor();
+  if (editor) {
+    const draft = await getDraftLesson(lessonId, DRAFT_FLASHCARD, editor);
+    if (!draft) redirect("/dashboard");
+
+    return (
+      <LessonPreview
+        initialLesson={draft}
+        serverURL={process.env.NEXT_PUBLIC_SERVER_URL || ""}
+      />
+    );
+  }
 
   // Accepts a slug or a legacy Mongo id — getLessonBySlug falls back to
   // SourceId, so old /lesson/<ObjectId> bookmarks keep working.

--- a/src/app/(app)/(player)/newlesson/[slug]/page.tsx
+++ b/src/app/(app)/(player)/newlesson/[slug]/page.tsx
@@ -1,6 +1,13 @@
 import { redirect } from "next/navigation";
 import NewLessonPlayer from "../../../../../pages-client/NewLessonPlayer";
-import { getNewLessonBySlug } from "../../../../../lib/content/content";
+import NewLessonPreview from "../../../../../pages-client/preview/NewLessonPreview";
+import {
+  DRAFT_STEP,
+  getDraftLesson,
+  getDraftNextSlug,
+  getNewLessonBySlug,
+} from "../../../../../lib/content/content";
+import { getPreviewEditor } from "../../../../../lib/session";
 
 export default async function Page({
   params,
@@ -8,6 +15,27 @@ export default async function Page({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
+
+  /*
+   * The CMS preview path. Draft Mode is only ever on for a request that came
+   * through /api/preview, and `getPreviewEditor` re-checks that editor against
+   * `cms_admins` rather than trusting the cookie. Anything short of a real
+   * editor falls through to the published path below, unchanged.
+   */
+  const editor = await getPreviewEditor();
+  if (editor) {
+    const draft = await getDraftLesson(slug, DRAFT_STEP, editor);
+    if (!draft) redirect("/dashboard");
+
+    return (
+      <NewLessonPreview
+        initialLesson={draft}
+        nextSlug={await getDraftNextSlug(draft, editor)}
+        serverURL={process.env.NEXT_PUBLIC_SERVER_URL || ""}
+      />
+    );
+  }
+
   const lesson = await getNewLessonBySlug(slug);
 
   // Matches the CRA behaviour: a lesson that can't be fetched sends the user

--- a/src/app/(app)/(site)/resources/page.tsx
+++ b/src/app/(app)/(site)/resources/page.tsx
@@ -1,7 +1,21 @@
 import Resources from "../../../../pages-client/Resources";
-import { getResources } from "../../../../lib/content/content";
+import ResourcesPreview from "../../../../pages-client/preview/ResourcesPreview";
+import { getDraftResources, getResources } from "../../../../lib/content/content";
+import { getPreviewEditor } from "../../../../lib/session";
 
 export default async function Page() {
+  // The CMS preview path — see the note in the step player's page. Draft Mode
+  // alone is not enough; the editor is re-checked against `cms_admins`.
+  const editor = await getPreviewEditor();
+  if (editor) {
+    return (
+      <ResourcesPreview
+        initialGroups={await getDraftResources(editor)}
+        serverURL={process.env.NEXT_PUBLIC_SERVER_URL || ""}
+      />
+    );
+  }
+
   const groups = await getResources();
   return (
     <Resources

--- a/src/app/(app)/api/exit-preview/route.ts
+++ b/src/app/(app)/api/exit-preview/route.ts
@@ -1,0 +1,16 @@
+import { draftMode } from "next/headers";
+import { NextResponse } from "next/server";
+
+/*
+ * The way back out of Draft Mode.
+ *
+ * Not optional housekeeping: the cookie /api/preview sets applies to every
+ * route on the origin and survives until the browser closes. Without this an
+ * editor who previewed one lesson keeps seeing unpublished content everywhere
+ * they browse afterwards, with nothing on screen to say so.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const draft = await draftMode();
+  draft.disable();
+  return NextResponse.redirect(new URL("/", request.url));
+}

--- a/src/app/(app)/api/preview/route.ts
+++ b/src/app/(app)/api/preview/route.ts
@@ -1,0 +1,71 @@
+import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { payloadClient } from "../../../../lib/content/payload";
+import { isPreviewablePath } from "../../../../lib/content/routes";
+
+/*
+ * The only thing in the app that turns Draft Mode on.
+ *
+ * Two independent checks, and both have to pass:
+ *
+ *  - `previewSecret` proves the link came out of our own admin. Payload puts it
+ *    in the Live Preview iframe's `src`, so any signed-in editor can read it
+ *    back out of the DOM — it filters stray requests, it is not the boundary.
+ *  - `payload.auth()` is the boundary. It validates the `payload-token` cookie
+ *    against `cms_admins`. The admin is mounted on this same origin, so that
+ *    cookie is first-party and rides along with the iframe's request.
+ *
+ * This route sits in the (app) group while Payload's REST catch-all sits at
+ * (payload)/api/[...slug]. They do not collide: Next only rejects two files
+ * resolving to the *same* path, and a literal segment wins over a catch-all.
+ * /api/progress and /api/pronunciation/check already live here the same way.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const path = searchParams.get("path");
+  const previewSecret = searchParams.get("previewSecret");
+
+  // Fail closed: an unset secret has to refuse everything, not wave everything
+  // through on `undefined === undefined`.
+  const expected = process.env.PREVIEW_SECRET;
+  if (!expected || previewSecret !== expected) {
+    return new Response("You are not allowed to preview this page", {
+      status: 403,
+    });
+  }
+
+  // Allowlisted, not merely "starts with a slash" — "//evil.com" passes that
+  // test and is a protocol-relative URL. See `isPreviewablePath`.
+  if (!path || !isPreviewablePath(path)) {
+    return new Response("Not a previewable path", { status: 400 });
+  }
+
+  const payload = await payloadClient();
+  const draft = await draftMode();
+
+  let user;
+  try {
+    // Destructured, not assigned whole: `payload.auth()` resolves to
+    // `{ user, permissions }`, an object that is truthy whether or not anyone
+    // is signed in. Testing the result itself would let everyone through.
+    ({ user } = await payload.auth({ headers: request.headers }));
+  } catch (err) {
+    payload.logger.error({ err, msg: "Preview auth check failed" });
+    return new Response("You are not allowed to preview this page", {
+      status: 403,
+    });
+  }
+
+  if (!user) {
+    // Clears a cookie an earlier session left behind, so someone who has since
+    // signed out of /admin stops seeing drafts on the public site.
+    draft.disable();
+    return new Response("You are not allowed to preview this page", {
+      status: 403,
+    });
+  }
+
+  draft.enable();
+  redirect(path);
+}

--- a/src/lib/content/content.ts
+++ b/src/lib/content/content.ts
@@ -1,8 +1,9 @@
 import "server-only";
 import { unstable_cache } from "next/cache";
-import type { Where } from "payload";
+import type { TypedUser, Where } from "payload";
 import { payloadClient } from "./payload";
 import { TAGS } from "./tags";
+import { lessonHref } from "./routes";
 import {
   toLessonDoc,
   toLessonListItem,
@@ -10,7 +11,7 @@ import {
   toNewLessonListItem,
   toResourceGroup,
 } from "./adapters";
-import type { Lesson } from "../../payload/payload-types";
+import type { Lesson, Resource } from "../../payload/payload-types";
 import type {
   LessonDoc,
   LessonListItem,
@@ -237,10 +238,7 @@ export function getLessonRoute(slugOrLegacyId: string): Promise<LessonRoute | nu
         title: lesson.title,
         version: lesson.version ?? "",
         prefecture: lesson.prefecture ?? "",
-        href:
-          lesson.format === "flashcard"
-            ? `/lesson/${lesson.slug}`
-            : `/newlesson/${lesson.slug}`,
+        href: lessonHref(lesson.format, lesson.slug),
       };
     },
     ["content", "getLessonRoute", key],
@@ -249,4 +247,119 @@ export function getLessonRoute(slugOrLegacyId: string): Promise<LessonRoute | nu
       revalidate: REVALIDATE,
     }
   )();
+}
+
+// ── Draft reads: the CMS preview panel, and nothing else ─────────────────────
+/*
+ * Everything above answers for the public site: published only, cached, tagged.
+ * The three lookups below answer for Live Preview, and differ on every one of
+ * those axes.
+ *
+ * They return the raw Payload document rather than the view model the players
+ * consume. The preview wrapper needs the raw shape because `useLivePreview`
+ * merges the editor's unsaved form state into it and hands back another raw
+ * document, and the wrapper then runs the same adapters this module runs — on
+ * the client. That works only because `adapters.ts` is deliberately free of
+ * `server-only`, and it is what keeps preview from growing a second copy of the
+ * document-to-player mapping that could drift from this one.
+ *
+ * Not wrapped in `unstable_cache`. A preview load is one query, once, so there
+ * is nothing to win, and a cached draft is a wrong answer waiting to be served
+ * to somebody.
+ *
+ * `overrideAccess: false` is kept, with the authenticated editor passed as
+ * `user`. These reads stay on the same access rules as every other read rather
+ * than being exempted from them — the caller has already proved who it is (see
+ * `getPreviewEditor` in `lib/session.ts`).
+ */
+
+/** Which player to narrow a draft lookup to. The public lookups use these too. */
+export const DRAFT_FLASHCARD = FLASHCARD;
+export const DRAFT_STEP = STEP;
+
+async function findDrafts(
+  where: Where,
+  user: TypedUser,
+  limit = 0
+): Promise<Lesson[]> {
+  const payload = await payloadClient();
+  const result = await payload.find({
+    collection: "lessons",
+    where,
+    limit,
+    depth: 0,
+    draft: true,
+    sort: ["order", "createdAt"],
+    overrideAccess: false,
+    user,
+    pagination: false,
+  });
+  return result.docs;
+}
+
+/**
+ * The draft behind a preview URL, raw.
+ *
+ * Narrowed by `format` exactly as the published lookups are, so /lesson/<slug>
+ * still cannot preview a step lesson in the wrong player. The slug-then-
+ * `sourceId` fallback is kept as well: a legacy id remains a valid way to reach
+ * a lesson, and the preview URL is built from whatever the editor has open.
+ */
+export async function getDraftLesson(
+  slugOrLegacyId: string,
+  format: Where,
+  user: TypedUser
+): Promise<Lesson | null> {
+  const key = String(slugOrLegacyId || "").trim();
+  if (!key) return null;
+
+  const [lesson] = await findDrafts(and(format, byKey(key)), user, 1);
+  return lesson ?? null;
+}
+
+/**
+ * `nextSlug` for a draft — the same course-order lookup as `nextSlugFor`, but
+ * resolved against drafts too. An editor writing a course should see the lesson
+ * they just added as the one that follows, not skip over it to the last
+ * published one.
+ */
+export async function getDraftNextSlug(
+  lesson: Lesson,
+  user: TypedUser
+): Promise<string | undefined> {
+  const courseId = typeof lesson.course === "object" ? lesson.course?.id : lesson.course;
+  if (courseId === null || courseId === undefined || lesson.order === null || lesson.order === undefined) {
+    return undefined;
+  }
+
+  const payload = await payloadClient();
+  const result = await payload.find({
+    collection: "lessons",
+    where: and(STEP, {
+      course: { equals: courseId },
+      order: { greater_than: lesson.order },
+    }),
+    limit: 1,
+    depth: 0,
+    draft: true,
+    sort: "order",
+    overrideAccess: false,
+    user,
+  });
+
+  return result.docs[0]?.slug;
+}
+
+export async function getDraftResources(user: TypedUser): Promise<Resource[]> {
+  const payload = await payloadClient();
+  const result = await payload.find({
+    collection: "resources",
+    depth: 0,
+    draft: true,
+    sort: "createdAt",
+    overrideAccess: false,
+    user,
+    pagination: false,
+  });
+  return result.docs;
 }

--- a/src/lib/content/routes.ts
+++ b/src/lib/content/routes.ts
@@ -1,0 +1,57 @@
+/*
+ * Where a document is served on the front end.
+ *
+ * A leaf module with no imports, for the same reason `tags.ts` is one: this is
+ * read both by `content.ts`, which carries `server-only`, and — through
+ * `payload/preview.ts` — by `payload.config.ts`, which the Payload CLI loads in
+ * plain Node where `server-only` throws.
+ *
+ * The lesson mapping lived inline in `getLessonRoute` until live preview needed
+ * it too. It is stated once here rather than twice, because the two copies
+ * would be the same fact: which player a lesson plays in.
+ */
+
+/** Which player a lesson plays in. Mirrors `format` on the Lessons collection. */
+export function lessonHref(format: string | null | undefined, slug: string): string {
+  return format === "flashcard" ? `/lesson/${slug}` : `/newlesson/${slug}`;
+}
+
+/**
+ * The page that renders a document, or null when there isn't one.
+ *
+ * Null for a lesson with no slug — a document the editor has not saved yet has
+ * nothing to point an iframe at — and null for every collection without a page
+ * of its own, which is why `courses` and `media` are absent rather than listed
+ * and handled.
+ */
+export function previewPath(
+  collection: string,
+  doc: Record<string, unknown> | null | undefined
+): string | null {
+  if (collection === "resources") return "/resources";
+
+  if (collection === "lessons") {
+    const slug = typeof doc?.slug === "string" ? doc.slug.trim() : "";
+    if (!slug) return null;
+    return lessonHref(typeof doc?.format === "string" ? doc.format : null, slug);
+  }
+
+  return null;
+}
+
+/*
+ * The allowlist `/api/preview` redirects against.
+ *
+ * Matching the two real path families exactly, rather than testing that the
+ * path is relative. Payload's own documentation sample checks
+ * `path.startsWith('/')`, which "//evil.com" satisfies — that is a
+ * protocol-relative URL, and it would turn the preview route into an open
+ * redirect for anyone holding the secret. Slugs are matched against the
+ * unreserved URL character set; every slug in the content model is narrower
+ * than that.
+ */
+const PREVIEWABLE = /^\/(?:lesson|newlesson)\/[A-Za-z0-9._~-]+$|^\/resources$/;
+
+export function isPreviewablePath(path: string): boolean {
+  return PREVIEWABLE.test(path);
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,7 +1,8 @@
 import "server-only";
-import { headers } from "next/headers";
+import { draftMode, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "./auth";
+import { payloadClient } from "./content/payload";
 
 /** Current session, or null. Server-side only. */
 export async function getSession() {
@@ -17,4 +18,47 @@ export async function requireSession() {
   const session = await getSession();
   if (!session) redirect("/auth");
   return session;
+}
+
+/**
+ * The CMS editor behind a Draft Mode request, or null.
+ *
+ * Draft Mode's cookie is a build-scoped bearer token. Next checks its value
+ * against a random per-build id, so it cannot be forged in production — but it
+ * names nobody, it keeps working after the editor who obtained it signs out of
+ * /admin or is removed from `cms_admins`, and in development Next accepts any
+ * value for it at all. So the cookie only says "this request wants drafts";
+ * *who* is asking is re-checked here, against Payload, on every request.
+ *
+ * Returning the user rather than a boolean because the draft reads in
+ * `lib/content/content.ts` pass it to `payload.find` as `user`, which keeps
+ * those reads on the same access rules as every other read in the app.
+ */
+export async function getPreviewEditor() {
+  const { isEnabled } = await draftMode();
+  if (!isEnabled) return null;
+
+  const payload = await payloadClient();
+  try {
+    const { user } = await payload.auth({ headers: await headers() });
+    return user ?? null;
+  } catch (err) {
+    // Same reasoning as the Media read gate: a failure here is "not an
+    // editor", not a 500 on the page.
+    payload.logger.error({ err, msg: "Preview editor check failed" });
+    return null;
+  }
+}
+
+/**
+ * The gate on the lesson players.
+ *
+ * A learner needs a better-auth session. A CMS editor previewing a draft does
+ * not have one and never will — the two identity systems are unrelated, the
+ * same split the Media collection's read access already straddles. Either
+ * identity gets in; neither gets in on the strength of a cookie alone.
+ */
+export async function requirePlayerAccess() {
+  if (await getPreviewEditor()) return null;
+  return requireSession();
 }

--- a/src/pages-client/LessonPlayer.tsx
+++ b/src/pages-client/LessonPlayer.tsx
@@ -232,8 +232,6 @@ const Lesson: React.FC<{ lessonId: string; lesson: LessonDoc }> = ({ lessonId, l
   const resumedRef = useRef(false);
 
   useEffect(() => {
-    resumedRef.current = false;
-
     setLesson(lessonProp);
     setDebugInfo({
       lessonIdParam: lessonId,
@@ -251,12 +249,24 @@ const Lesson: React.FC<{ lessonId: string; lesson: LessonDoc }> = ({ lessonId, l
       })),
       prefecture: (lessonProp as any)?.prefecture,
     });
+  }, [lessonProp]);
 
+  /*
+   * Position and score reset on the lesson's *identity*, not on the object it
+   * arrived in. Split from the content update above for CMS Live Preview:
+   * there this component is handed a freshly built lesson on every keystroke,
+   * and resetting on object identity would send the editor back to card 1 and
+   * wipe the running score each time they typed a character. On the public
+   * path the two fire together — a different lesson means both a different
+   * `lessonId` and a different object.
+   */
+  useEffect(() => {
+    resumedRef.current = false;
     setStep(0);
     setCorrectCount(0);
     setAttemptCount(0);
     answeredStepRef.current = {};
-  }, [lessonId, lessonProp]);
+  }, [lessonId]);
 
   const lessonKey = useMemo(() => (lesson ? resolveLessonIdentifier(lesson) : ""), [lesson]);
 
@@ -545,12 +555,16 @@ const Lesson: React.FC<{ lessonId: string; lesson: LessonDoc }> = ({ lessonId, l
       setStep(nextStep);
 
       if (lesson && lessonKey) {
+        // Caught, like the save-and-exit call below. Progress is best-effort
+        // here, and in the CMS preview panel there is no learner session at
+        // all, so every one of these 401s — unhandled, that is a rejection per
+        // card turned.
         void upsertProgress({
           lessonId: lessonKey,
           status: "in_progress",
           lastStep: nextStep,
           accuracyPct: nextAccuracy,
-        });
+        }).catch((e) => console.error("[Progress] save failed:", e));
       }
     } else {
       if (lesson && lessonKey) {
@@ -559,7 +573,7 @@ const Lesson: React.FC<{ lessonId: string; lesson: LessonDoc }> = ({ lessonId, l
           status: "completed",
           lastStep: step,
           accuracyPct: nextAccuracy,
-        });
+        }).catch((e) => console.error("[Progress] save failed:", e));
       }
 
       router.push("/new-lessons");

--- a/src/pages-client/NewLessonPlayer.tsx
+++ b/src/pages-client/NewLessonPlayer.tsx
@@ -201,10 +201,29 @@ const NewLessonPage: React.FC<{ slug: string; lesson: NewLessonDoc }> = ({ slug,
   const [items, setItems] = useState<NewLessonItem[] | null>(null);
 
   useEffect(() => {
-    resumedRef.current = false;
-    setStep(0);
     setItems(expandLessonItems(lesson.items ?? []));
   }, [lesson]);
+
+  /*
+   * Position resets on the lesson's *identity*, not on the object it arrived
+   * in. Split from the expansion above for CMS Live Preview: there this
+   * component is handed a freshly built lesson on every keystroke, and
+   * resetting on object identity would throw the editor back to step 1 each
+   * time they typed a character. On the public path the two fire together —
+   * a different lesson means both a different slug and a different object.
+   */
+  useEffect(() => {
+    resumedRef.current = false;
+    setStep(0);
+  }, [lesson.slug]);
+
+  // The expansion shrinks when an editor deletes an exercise mid-preview.
+  // Keep the cursor inside it rather than rendering a blank step.
+  useEffect(() => {
+    if (items && items.length > 0 && step >= items.length) {
+      setStep(items.length - 1);
+    }
+  }, [items, step]);
 
   // Resume at the last-seen exercise (by content key, since the expansion
   // above re-shuffles order every visit — a raw saved index could point at a

--- a/src/pages-client/preview/LessonPreview.tsx
+++ b/src/pages-client/preview/LessonPreview.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useLivePreview } from "@payloadcms/live-preview-react";
+
+import LessonPlayer from "../LessonPlayer";
+import { toLessonDoc } from "../../lib/content/adapters";
+import type { Lesson } from "../../payload/payload-types";
+
+/*
+ * The Live Preview seam for the flashcard player. Same shape as
+ * `NewLessonPreview` — see the note there for why the adapter runs on the
+ * client and why `depth: 0` is enough.
+ */
+export default function LessonPreview({
+  initialLesson,
+  serverURL,
+}: {
+  initialLesson: Lesson;
+  serverURL: string;
+}) {
+  const { data } = useLivePreview<Lesson>({
+    initialData: initialLesson,
+    serverURL,
+    depth: 0,
+  });
+
+  const lesson = toLessonDoc(data);
+  return <LessonPlayer lessonId={lesson.slug} lesson={lesson} />;
+}

--- a/src/pages-client/preview/NewLessonPreview.tsx
+++ b/src/pages-client/preview/NewLessonPreview.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useLivePreview } from "@payloadcms/live-preview-react";
+
+import NewLessonPlayer from "../NewLessonPlayer";
+import { toNewLessonDoc } from "../../lib/content/adapters";
+import type { Lesson } from "../../payload/payload-types";
+
+/*
+ * The Live Preview seam for the step-through player.
+ *
+ * The server hands down the raw Payload document; `useLivePreview` subscribes
+ * to the admin's `postMessage` stream and merges the editor's unsaved form
+ * state into it, giving back another raw document. Running `toNewLessonDoc` on
+ * that — the very adapter the server path runs — puts the real player in front
+ * of unsaved content without a second copy of the mapping to keep in step.
+ *
+ * `depth: 0` matches the server read. Nothing here needs populating: the only
+ * relationship on a lesson is `course`, used as a bare id, and every media
+ * field on a block is a plain URL string rather than an upload relation.
+ */
+export default function NewLessonPreview({
+  initialLesson,
+  nextSlug,
+  serverURL,
+}: {
+  initialLesson: Lesson;
+  /*
+   * Resolved once on the server and then held. The next lesson comes from a
+   * second query against course order, and the hook only ever streams the
+   * document the editor has open — there is nothing on the client to
+   * re-resolve it from. It goes stale if they reorder the course mid-preview,
+   * which a save and a reload fixes; the alternative is a fetch per keystroke.
+   */
+  nextSlug?: string;
+  /** The exact origin /admin is served from — the hook checks it against the
+   * message origin, so a mismatch silently drops every update. Read on the
+   * server and passed down, so there is one place to look when it is wrong. */
+  serverURL: string;
+}) {
+  const { data } = useLivePreview<Lesson>({
+    initialData: initialLesson,
+    serverURL,
+    depth: 0,
+  });
+
+  const lesson = toNewLessonDoc(data, nextSlug);
+  return <NewLessonPlayer slug={lesson.slug} lesson={lesson} />;
+}

--- a/src/pages-client/preview/ResourcesPreview.tsx
+++ b/src/pages-client/preview/ResourcesPreview.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useLivePreview } from "@payloadcms/live-preview-react";
+
+import Resources from "../Resources";
+import { toResourceGroup } from "../../lib/content/adapters";
+import type { Resource } from "../../payload/payload-types";
+
+/*
+ * The Live Preview seam for /resources.
+ *
+ * Unlike a lesson, a resource group has no page of its own — every group is a
+ * section of one page. `useLivePreview` streams only the document the editor
+ * has open, so the live copy is spliced back into the server-rendered list by
+ * id and the rest are left as they were. That is the honest rendering: the
+ * group being edited updates as it is typed, the others show what is currently
+ * saved.
+ */
+export default function ResourcesPreview({
+  initialGroups,
+  serverURL,
+}: {
+  initialGroups: Resource[];
+  serverURL: string;
+}) {
+  // The hook requires initial data, and an empty collection has none to give.
+  // A placeholder keeps the hook unconditional (it cannot be called behind an
+  // early return) while rendering nothing.
+  const { data } = useLivePreview<Resource>({
+    initialData: initialGroups[0] ?? ({} as Resource),
+    serverURL,
+    depth: 0,
+  });
+
+  const groups = initialGroups
+    .map((group) => (data && group.id === data.id ? data : group))
+    .map(toResourceGroup);
+
+  return (
+    <Resources
+      data={groups.map((g) => ({
+        id: g.id,
+        category: g.category,
+        items: g.items as never[],
+      }))}
+    />
+  );
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -5,6 +5,7 @@ import { postgresAdapter } from "@payloadcms/db-postgres";
 import { buildConfig } from "payload";
 
 import { vercelPrivateBlobStorage } from "./payload/storage/vercelPrivateBlob";
+import { livePreviewURL } from "./payload/preview";
 
 import { CmsAdmins } from "./payload/collections/CmsAdmins";
 import { Courses } from "./payload/collections/Courses";
@@ -36,17 +37,35 @@ export default buildConfig({
   admin: {
     user: CmsAdmins.slug,
     meta: { titleSuffix: "— Nihon-Go! CMS" },
+    /*
+     * Live Preview renders the real front end in a panel beside the editing
+     * form and pushes the unsaved form state into it over `postMessage`, so an
+     * editor sees a lesson as a learner would while they are still typing it.
+     *
+     * `url` points at /api/preview, not at the page: Draft Mode is a cookie
+     * only a route handler can set, and that handler is where the request is
+     * checked. See `payload/preview.ts` for what goes into the URL and
+     * `app/(app)/api/preview/route.ts` for what happens to it.
+     */
     livePreview: {
-      // Points to the frontend route that initializes Draft Mode
-      url: ({ data, collectionConfig }) => {
-        const baseUrl =
-          process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:3000";
-        return `${baseUrl}/api/preview?slug=${data.slug}&collection=${collectionConfig?.slug ?? ""}`;
-      },
-      collections: [Courses.slug, Lessons.slug, Resources.slug, Media.slug], // Collections supporting Live Preview
+      url: livePreviewURL,
+      // Only the two collections with a page of their own. A course is a
+      // grouping with no route, and media is an upload — there is nothing for
+      // the iframe to load in either case.
+      collections: [Lessons.slug, Resources.slug],
+      // Payload adds "responsive" itself; these are the fixed sizes to check a
+      // lesson against, and the phone is the one that matters most here.
+      breakpoints: [
+        { name: "mobile", label: "Mobile", width: 390, height: 844 },
+        { name: "tablet", label: "Tablet", width: 768, height: 1024 },
+        { name: "desktop", label: "Desktop", width: 1440, height: 900 },
+      ],
     },
   },
-  collections: [Courses, Lessons, Resources, Media],
+  // CmsAdmins is `admin.user` above — leaving it out of this list points the
+  // admin panel at a collection that was never registered, which takes out
+  // /admin login and `npm run payload:seed-admins` with it.
+  collections: [Courses, Lessons, Resources, Media, CmsAdmins],
   db: postgresAdapter({
     schemaName: "payload",
     push: false,

--- a/src/payload/access/readPublished.ts
+++ b/src/payload/access/readPublished.ts
@@ -1,0 +1,29 @@
+import type { Access } from "payload";
+
+/*
+ * Read access for the content collections: everything to a signed-in CMS user,
+ * published documents only to everyone else.
+ *
+ * The three content collections used to declare `read: () => true`, which is
+ * not "public read" — it is *no filter at all*. Payload's REST API is mounted
+ * publicly at /api/<collection>, and with `versions.drafts` on, the collection
+ * table holds the latest saved state of every document, draft included. So an
+ * unauthenticated `GET /api/lessons` returned unpublished lessons outright, and
+ * `?draft=true` additionally routed the query through `queryDrafts`. The app
+ * itself never saw them because `lib/content/content.ts` ANDs in
+ * `_status: published` on every read — but that made the app's own query the
+ * only thing standing between a draft and the internet.
+ *
+ * Returning a `Where` instead of a boolean is how Payload expresses "some of
+ * them": the constraint is merged into the query before it runs, on both the
+ * published and the drafts path, so it cannot be bypassed with a query
+ * parameter. The explicit filters in `content.ts` are now redundant rather than
+ * load-bearing, and are kept — the same rule stated in both places is cheap,
+ * and neither should be the only one.
+ *
+ * `req.user` is a `cms_admins` user, not a learner: this is the CMS identity,
+ * which is why the draft readers in `content.ts` pass the authenticated editor
+ * through as `user` rather than switching `overrideAccess` off.
+ */
+export const readPublishedOrEditor: Access = ({ req }) =>
+  req.user ? true : { _status: { equals: "published" } };

--- a/src/payload/collections/Courses.ts
+++ b/src/payload/collections/Courses.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from "payload";
 
 import { revalidateCourse, revalidateCourseDelete } from "../hooks/revalidate";
+import { readPublishedOrEditor } from "../access/readPublished";
 
 /*
  * A course is an ordered track of lessons. It replaces the old `nextSlug`
@@ -17,7 +18,7 @@ export const Courses: CollectionConfig = {
     group: "Content",
     description: "Tracks that group lessons into an ordered sequence.",
   },
-  access: { read: () => true },
+  access: { read: readPublishedOrEditor },
   hooks: {
     afterChange: [revalidateCourse],
     afterDelete: [revalidateCourseDelete],

--- a/src/payload/collections/Lessons.ts
+++ b/src/payload/collections/Lessons.ts
@@ -4,6 +4,8 @@ import { grammarBlocks } from "../blocks/grammar";
 import { escapeHatchBlocks, legacyBlocks } from "../blocks/legacy";
 import { guardLessonDelete } from "../hooks/guardLessonDelete";
 import { revalidateLesson, revalidateLessonDelete } from "../hooks/revalidate";
+import { generatePreviewURL } from "../preview";
+import { readPublishedOrEditor } from "../access/readPublished";
 
 /*
  * One `lessons` collection replaces both Mongo collections — legacy `lessons`
@@ -50,8 +52,11 @@ export const Lessons: CollectionConfig = {
     group: "Content",
     listSearchableFields: ["title", "slug", "cardTitle"],
     description: "Every lesson, from both of the old lesson systems.",
+    // Opens the lesson in its own tab, in whichever player `format` selects.
+    // The Live Preview panel is the same destination, side by side instead.
+    preview: generatePreviewURL("lessons"),
   },
-  access: { read: () => true },
+  access: { read: readPublishedOrEditor },
   hooks: {
     beforeDelete: [guardLessonDelete],
     afterChange: [revalidateLesson],

--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -52,7 +52,12 @@ const readMedia: Access = async ({ req }) => {
 };
 export const Media: CollectionConfig = {
   slug: "media",
-  versions: { drafts: true },
+  // No `versions: { drafts: true }` here, unlike the content collections. An
+  // upload has no draft/publish cycle to model — a file is either in the store
+  // or it is not — and turning it on needs a `_status` column plus a `_media_v`
+  // table that the initial migration never created. With `push: false` nothing
+  // creates them at boot, so the admin's Media list would query a column that
+  // does not exist.
   labels: { singular: "Media", plural: "Media" },
   admin: {
     group: "Content",

--- a/src/payload/collections/Resources.ts
+++ b/src/payload/collections/Resources.ts
@@ -4,6 +4,8 @@ import {
   revalidateResources,
   revalidateResourcesDelete,
 } from "../hooks/revalidate";
+import { generatePreviewURL } from "../preview";
+import { readPublishedOrEditor } from "../access/readPublished";
 
 /*
  * The /resources page: a handful of named groups, each a list of links.
@@ -23,8 +25,11 @@ export const Resources: CollectionConfig = {
     group: "Content",
     description:
       "Link collections shown on the Resources page, grouped by category.",
+    // Every group shares one page, so this opens /resources rather than a page
+    // belonging to this document.
+    preview: generatePreviewURL("resources"),
   },
-  access: { read: () => true },
+  access: { read: readPublishedOrEditor },
   hooks: {
     afterChange: [revalidateResources],
     afterDelete: [revalidateResourcesDelete],

--- a/src/payload/preview.ts
+++ b/src/payload/preview.ts
@@ -1,0 +1,63 @@
+import type { CollectionConfig, LivePreviewConfig } from "payload";
+
+import { previewPath } from "../lib/content/routes";
+
+/*
+ * The two doors into Draft Mode, and the only two.
+ *
+ * `livePreviewURL` feeds `admin.livePreview.url` — the iframe that renders the
+ * front end beside the editing form. `generatePreviewURL` feeds each
+ * collection's `admin.preview` — the "Preview" button that opens the same page
+ * in a tab. Both point at /api/preview rather than at the page itself, because
+ * Draft Mode can only be switched on by a route handler, and that handler is
+ * where the request gets checked.
+ *
+ * No `server-only` import: `payload.config.ts` pulls this in, and the Payload
+ * CLI loads that config in plain Node for `generate:types` and `migrate:create`.
+ *
+ * Reading PREVIEW_SECRET here does not ship it to the browser. Payload strips
+ * `livePreview.url` and `admin.preview` when it builds the client config — they
+ * are server-only properties — so the function never crosses the bundle
+ * boundary. The URL it returns does, as the iframe's `src`, which is exactly
+ * why /api/preview treats the secret as a filter and checks the editor's
+ * session separately.
+ */
+
+function serverURL(): string {
+  return process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:3000";
+}
+
+function buildPreviewURL(
+  collection: string,
+  doc: Record<string, unknown> | null | undefined
+): string | null {
+  const path = previewPath(collection, doc);
+  if (!path) return null;
+
+  // Fail closed. /api/preview refuses every request when the secret is unset,
+  // so returning null here hides preview in the admin rather than offering a
+  // button that always 403s.
+  const secret = process.env.PREVIEW_SECRET;
+  if (!secret) return null;
+
+  const url = new URL("/api/preview", serverURL());
+  url.searchParams.set("previewSecret", secret);
+  url.searchParams.set("collection", collection);
+  url.searchParams.set("path", path);
+  return url.toString();
+}
+
+export const livePreviewURL: NonNullable<LivePreviewConfig["url"]> = ({
+  data,
+  collectionConfig,
+}) =>
+  collectionConfig
+    ? buildPreviewURL(collectionConfig.slug, data as Record<string, unknown>)
+    : null;
+
+/** `admin.preview` for one collection — the Preview button, same destination. */
+export function generatePreviewURL(
+  collection: string
+): NonNullable<NonNullable<CollectionConfig["admin"]>["preview"]> {
+  return (doc) => buildPreviewURL(collection, doc as Record<string, unknown>);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,6 +19,15 @@ import { getSessionCookie } from "better-auth/cookies";
 export function proxy(request: NextRequest) {
   if (getSessionCookie(request)) return NextResponse.next();
 
+  /*
+   * A Draft Mode request from the CMS preview panel. Presence only, the same
+   * optimistic rule the session cookie above gets: the Proxy runs on the edge,
+   * where it can reach neither Payload nor the build's preview id, so it cannot
+   * do better than this. The (player) layout re-checks the editor against
+   * `cms_admins`, which is where a bad cookie is caught.
+   */
+  if (request.cookies.has("__prerender_bypass")) return NextResponse.next();
+
   const url = new URL("/auth", request.url);
   // Preserves the CRA behaviour of returning the user to the page they wanted
   // (react-router carried this in location.state.from).


### PR DESCRIPTION
Finishes the Live Preview work started in be6fa7c / 5b7c4ce, which landed config only — `admin.livePreview.url` pointed at `/api/preview`, a route that did not exist, so the panel loaded a 404.

An editor can now open a lesson or a resource group in `/admin` and watch the real front end update **as they type**, with no save.

## What's here

**Live Preview (real-time, not refresh-on-save).** `useLivePreview` streams the unsaved form state to a thin client wrapper, which runs the *same* pure adapters from `lib/content/adapters.ts` that the server runs and hands the result to the existing player. That module was already deliberately free of `server-only`, which is what makes this possible without a second copy of the document-to-player mapping.

**Draft Mode entry point.** `/api/preview` is the only thing in the app that can enable Draft Mode, and it checks two things:

- `previewSecret` — proves the link came from our own admin. Payload puts it in the iframe's `src`, where any signed-in editor can read it, so this filters; it is not the boundary.
- `payload.auth()` — a live `cms_admins` session. This is the boundary.

`/api/exit-preview` clears it. Not optional: the cookie is origin-wide and survives until the browser closes, so without it an editor keeps seeing drafts while browsing normally.

**Auth.** A CMS editor has a `payload-token`, not a better-auth learner session, so `requirePlayerAccess()` admits either. `proxy.ts` lets the Draft Mode cookie past on presence alone — safe *only* because the layout behind it re-checks the editor on every request. The cookie is a build-scoped token that names nobody and outlives the admin session that obtained it.

**Player reset fix (required, not polish).** Both players reset on the lesson *object*, and `useLivePreview` returns a new object per keystroke — as written the preview snapped back to step 1 on every character typed. Resets now key on identity (`slug` / `lessonId`); content updates stay on the object. Behaviour-preserving on the public path, where the two always change together.

## Security fix

`lessons`, `courses` and `resources` declared `read: () => true`. That is not "public read" — it is *no filter at all*, and Payload's REST API is mounted publicly. Anonymous `GET /api/lessons` returned unpublished documents outright, `?draft=true` or not. The app looked safe only because `content.ts` happened to AND in `_status: published`, which made the app's own query the sole thing between a draft and the internet.

They now share `readPublishedOrEditor`, which returns a `Where` for anonymous callers. Payload merges that into the query on both the published and the `queryDrafts` path, so no query parameter gets around it.

| Anonymous request | Before | After |
|---|---|---|
| `GET /api/lessons` | 2 drafts + 1 published | published only |
| `GET /api/lessons?draft=true` | 2 drafts + 1 published | published only |
| `?draft=true&where[_status][equals]=draft` | drafts | 0 results |
| `GET /api/lessons/2?draft=true` (draft doc) | 200 | 404 |
| `GET /api/resources?draft=true` | draft group | published only |

## Two regressions from the earlier commits on this branch

- **`CmsAdmins` was dropped from `collections`** while `admin.user` still referenced it, leaving `/admin` login and `payload:seed-admins` pointed at an unregistered collection.
- **`versions: { drafts: true }` was added to Media with no migration.** The initial migration creates `payload.media` with no `_status` column and no `_media_v` table, and `push: false` means nothing creates them at boot — the admin's Media list queried a column that did not exist. Uploads have no draft/publish cycle to model, so this is reverted rather than migrated. `payload generate:types` now produces no diff.

## New env vars

Both documented in `.env.example`, `README.md` and `docs/CUTOVER.md`.

- `PREVIEW_SECRET` — fails closed. Unset, `/api/preview` 403s everything and the admin hides Live Preview rather than offering a panel that 403s.
- `NEXT_PUBLIC_SERVER_URL` — referenced in `payload.config.ts` today but documented nowhere. Must be the exact origin `/admin` is served from; it is what the front end checks preview messages against. **Unlike `BETTER_AUTH_URL`, set it on every environment**, each to its own URL — on Preview use the stable `*-git-<branch>` alias.

## Verification

`npm run typecheck`, `npm run payload:types` (no diff), `npm run payload:check-migrations` all pass. There is no test suite. Driven manually against a local dev server:

- Typed in a field → panel updated with no save, **and held position on step 4**. Editing a block's body updated the rendered step the same way.
- `format` routing: step → `/newlesson/…`, flashcard → `/lesson/…`, both rendering never-published drafts.
- Resources: the open group updates live, the others stay as saved (they share one page).
- Courses and Media show no preview button and no Live Preview tab.
- Refusals: no/wrong secret → 403; valid secret without an admin session → 403 (cookie *cleared*, not set); `//evil.com`, `/dashboard`, `/admin`, `https://evil.com` → 400.
- **Draft cookie present + admin signed out → `/auth`.** The check the cookie cannot do on its own.
- Signed out, public `/resources` shows published groups only; `/api/exit-preview` clears draft mode.

## Notes for the reviewer

- **`admin.livePreview.url` never reaches the browser** — Payload strips it when building the client config, so reading `PREVIEW_SECRET` there does not ship it in a bundle. The resulting URL string *does* reach the admin DOM, which is why the secret is one of two checks.
- **Known edges, both documented:** a step lesson's "next lesson" is resolved once at preview load and goes stale if the course is reordered mid-panel; on `/resources` only the group being edited updates live.
- **Unrelated, pre-existing:** `npm run payload:migrate` cannot complete on a database that already has `user_progress` rows whose `lesson_id` is not in `payload.lessons` — the FK migration fails. Not touched here.