### PR TITLE
fix(pronunciation): hand the container audio it can actually fetch

### DIFF
--- a/src/app/(app)/api/pronunciation/check/route.ts
+++ b/src/app/(app)/api/pronunciation/check/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "../../../../../lib/session";
+import { resolveReferenceAudio } from "../../../../../lib/pronunciation-reference";
 
 /*
  * Proxies pronunciation scoring to the standalone container service.
@@ -66,9 +67,14 @@ export async function POST(request: Request) {
     );
   }
 
+  const resolved = await resolveReferenceAudio(referenceAudioUrl, request);
+  if ("error" in resolved) {
+    return NextResponse.json({ message: resolved.error }, { status: resolved.status });
+  }
+
   const upstream = new FormData();
   upstream.append("recording", recording, "recording.webm");
-  upstream.append("referenceAudioUrl", referenceAudioUrl);
+  upstream.append("referenceAudioUrl", resolved.url);
 
   try {
     const res = await fetch(`${serviceUrl.replace(/\/$/, "")}/check`, {

--- a/src/lib/pronunciation-reference.test.ts
+++ b/src/lib/pronunciation-reference.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+
+import { resolveReferenceAudio } from "./pronunciation-reference";
+
+/*
+ * The hop that broke pronunciation scoring in production, and did it two
+ * services away from where the 500 appeared.
+ *
+ * The container fetches the reference audio itself. Phase 1 moved media from
+ * absolute public Cloudinary URLs to app-relative, access-gated Payload
+ * uploads, so what it was handed stopped being fetchable — Node's fetch cannot
+ * parse a relative URL at all. The container's catch answered 500, the proxy
+ * passed that status through, and the proxy's own logging never fired because
+ * *its* request had succeeded. Nothing in the app logged a cause.
+ *
+ * So the cases below are about what this hands downstream, including the ones
+ * that must not silently forward something unusable.
+ */
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const request = (origin = "https://learn.nihongojp.com", cookie = "better-auth.session=abc") =>
+  new Request(`${origin}/api/pronunciation/check`, {
+    method: "POST",
+    headers: { cookie },
+  });
+
+/** Stubs fetch and records what it was called with. */
+function stubFetch(handler: (url: URL, init: RequestInit) => Response | Promise<Response>) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  globalThis.fetch = (async (input: URL | RequestInfo, init: RequestInit = {}) => {
+    const url = input instanceof URL ? input : new URL(String(input));
+    calls.push({ url: url.toString(), init });
+    return handler(url, init);
+  }) as typeof fetch;
+  return calls;
+}
+
+const redirectTo = (location: string) =>
+  new Response(null, { status: 302, headers: { location } });
+
+test("an app-relative path resolves to the signed URL the media route redirects to", async () => {
+  const signed = "https://blob.vercel-storage.com/kore.mp3?sig=deadbeef";
+  const calls = stubFetch(() => redirectTo(signed));
+
+  const out = await resolveReferenceAudio("/api/media/file/kore.mp3", request());
+
+  assert.deepEqual(out, { url: signed });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://learn.nihongojp.com/api/media/file/kore.mp3");
+});
+
+test("it asks its own origin, not a configured one", async () => {
+  // On a preview deployment a configured URL names production, which is the
+  // same trap the preview URL builder had.
+  const calls = stubFetch(() => redirectTo("https://blob.vercel-storage.com/x.mp3?sig=1"));
+
+  await resolveReferenceAudio("/api/media/file/x.mp3", request("https://cornerstone-git-abc.vercel.app"));
+
+  assert.ok(calls[0].url.startsWith("https://cornerstone-git-abc.vercel.app/"));
+});
+
+test("it carries the learner's cookie, which is what passes the media gate", async () => {
+  const calls = stubFetch(() => redirectTo("https://blob.vercel-storage.com/x.mp3?sig=1"));
+
+  await resolveReferenceAudio("/api/media/file/x.mp3", request(undefined, "better-auth.session=xyz"));
+
+  assert.equal((calls[0].init.headers as Record<string, string>).cookie, "better-auth.session=xyz");
+});
+
+test("it does not follow the redirect itself — the bytes are the container's job", async () => {
+  const calls = stubFetch(() => redirectTo("https://blob.vercel-storage.com/x.mp3?sig=1"));
+
+  await resolveReferenceAudio("/api/media/file/x.mp3", request());
+
+  assert.equal(calls[0].init.redirect, "manual");
+});
+
+test("an already-absolute URL is passed through untouched, and fetches nothing", async () => {
+  // Cloudinary links predating Phase 1 still resolve on their own.
+  const calls = stubFetch(() => redirectTo("should-not-be-called"));
+  const url = "https://res.cloudinary.com/demo/video/upload/kore.mp3";
+
+  assert.deepEqual(await resolveReferenceAudio(url, request()), { url });
+  assert.equal(calls.length, 0);
+});
+
+test("a denied read reports 403 rather than forwarding an unusable URL", async () => {
+  stubFetch(() => new Response("Forbidden", { status: 403 }));
+
+  const out = await resolveReferenceAudio("/api/media/file/kore.mp3", request());
+
+  assert.deepEqual(out, { error: "Not allowed to read the reference audio", status: 403 });
+});
+
+test("any other non-redirect is a 502, not a pass-through", async () => {
+  stubFetch(() => new Response("nope", { status: 404 }));
+
+  const out = await resolveReferenceAudio("/api/media/file/gone.mp3", request());
+
+  assert.equal("error" in out && out.status, 502);
+});
+
+test("a 302 with no Location does not resolve to undefined", async () => {
+  stubFetch(() => new Response(null, { status: 302 }));
+
+  const out = await resolveReferenceAudio("/api/media/file/kore.mp3", request());
+
+  assert.ok("error" in out);
+});
+
+test("an unreachable media route is a 502", async () => {
+  globalThis.fetch = (async () => {
+    throw new TypeError("fetch failed");
+  }) as typeof fetch;
+
+  const out = await resolveReferenceAudio("/api/media/file/kore.mp3", request());
+
+  assert.equal("error" in out && out.status, 502);
+});
+
+test("something that is neither a URL nor a path is rejected, not forwarded", async () => {
+  const calls = stubFetch(() => redirectTo("x"));
+
+  const out = await resolveReferenceAudio("PLACEHOLDER_AUDIO_URL", request());
+
+  assert.equal("error" in out && out.status, 400);
+  assert.equal(calls.length, 0);
+});

--- a/src/lib/pronunciation-reference.ts
+++ b/src/lib/pronunciation-reference.ts
@@ -1,0 +1,83 @@
+/*
+ * Reference audio, made fetchable by a service that has no session.
+ *
+ * `referenceAudioUrl` is whatever `termAudio()` resolved, which since Phase 1
+ * is a Payload upload's `url` — an app-relative, access-gated path like
+ * `/api/media/file/kore.mp3`. It used to be an absolute, public Cloudinary URL,
+ * and the container still assumes it can just fetch it: `pronunciationController`
+ * calls `fetch(audioUrl)` directly. Node's fetch cannot parse a relative URL, so
+ * it throws, the container's catch answers 500, and this route passes that
+ * status straight through — a 500 on /api/pronunciation/check whose cause is
+ * two services away and whose only trace is in the response body.
+ *
+ * Making the path absolute is not enough on its own. `/api/media/file/*` 403s
+ * anonymous requests by design (the `isReadingStaticFile` split in the Media
+ * collection), so the container would fail the same way with a different
+ * message.
+ *
+ * What that route *does* do, for a request that passes the gate, is 302 to a
+ * short-lived signed Blob URL — see `payload/storage/vercelPrivateBlob.ts`,
+ * which redirects and never proxies bytes. So this asks for the redirect while
+ * holding the learner's cookie, and hands the container the signed URL. The
+ * access check still happens, exactly once, in the place that owns it; the
+ * container fetches a capability that expires in five minutes and is never
+ * broadened.
+ *
+ * An already-absolute URL is passed through untouched — Cloudinary links
+ * predating Phase 1 still resolve, and nothing here should be in the business
+ * of rewriting them.
+ */
+export type Resolved = { url: string } | { error: string; status: number };
+
+export async function resolveReferenceAudio(
+  referenceAudioUrl: string,
+  request: Request,
+): Promise<Resolved> {
+  if (/^https?:\/\//i.test(referenceAudioUrl)) {
+    return { url: referenceAudioUrl };
+  }
+
+  if (!referenceAudioUrl.startsWith("/")) {
+    return {
+      error: "referenceAudioUrl must be an absolute URL or an app-relative path",
+      status: 400,
+    };
+  }
+
+  // Same origin as the request that arrived, rather than a configured one:
+  // this route is asking its own deployment for a redirect, and on a preview
+  // deployment the configured value names production. The preview URL builder
+  // learned the same lesson.
+  const target = new URL(referenceAudioUrl, new URL(request.url).origin);
+
+  let res: Response;
+  try {
+    res = await fetch(target, {
+      // The 302 is the whole payload — the bytes go to the container, not here.
+      redirect: "manual",
+      headers: { cookie: request.headers.get("cookie") ?? "" },
+    });
+  } catch (err) {
+    console.error("[pronunciation] could not reach the media route:", err);
+    return { error: "Could not resolve the reference audio", status: 502 };
+  }
+
+  const location = res.headers.get("location");
+  if (res.status === 302 && location) {
+    return { url: location };
+  }
+
+  // 403 here means the learner's cookie did not survive the hop, which is a
+  // different bug from the one above and worth saying so rather than letting
+  // the container report a generic failure.
+  console.error(
+    `[pronunciation] media route did not redirect: ${res.status} for ${referenceAudioUrl}`,
+  );
+  return {
+    error:
+      res.status === 403
+        ? "Not allowed to read the reference audio"
+        : "Reference audio could not be resolved",
+    status: res.status === 403 ? 403 : 502,
+  };
+}


### PR DESCRIPTION
`POST /api/pronunciation/check` has been returning 500 on production since #63
merged. The route itself was never touched — what changed is what flows through
it.

## What breaks

The container fetches the reference audio itself: `pronunciationController.ts`
calls `fetch(audioUrl)` directly. Phase 1 moved media from absolute, public
Cloudinary URLs to Payload uploads, whose `url` is an app-relative, access-gated
path — production serves `/api/media/file/kore.mp3`. Node's fetch cannot parse a
relative URL, so it throws, the container's catch answers 500, and this route
passes that status through verbatim.

That combination is why nothing in the app pointed at it. The proxy's own
`console.error` never fired, because the proxy's request *succeeded* — the
container answered, just with a 500. Vercel logged `500` on the route with an
empty `logs` array, and the only description of the cause sat in the response
body, two services from where it was raised.

Ruled out along the way: `PRONUNCIATION_SERVICE_URL` and `_SECRET` are both set
on Production and Preview, so it was never the 503 path; and `/api/progress`
returns 200 on the same `getSession()`, so it was never auth.

## The fix

Making the path absolute is not enough on its own — `/api/media/file/*` 403s
anonymous requests by design (the `isReadingStaticFile` split), so the container
would fail with a different message.

What that route *does* do for a request passing the gate is 302 to a short-lived
signed Blob URL, and never proxy bytes. So the proxy now asks for that redirect
while holding the learner's cookie and forwards the signed URL. The access check
still happens exactly once, in the place that owns it; the container gets a
capability that expires in five minutes; the Media gate is not widened.

No container change and no Cloud Run redeploy.

## Notes for review

- The resolver lives in `src/lib/` rather than in the route so it can be tested
  without importing `lib/auth`, which throws at module scope and opens a pool.
- Origin comes from the incoming request rather than configuration — on a
  preview deployment a configured URL names production, the same trap the
  preview URL builder had.
- Absolute URLs pass through untouched, so any pre-Phase-1 Cloudinary links
  still resolve.
- The container caches reference phonemes keyed by URL. Signed URLs rotate every
  five minutes, so that cache will miss more often than it did. Correctness is
  unaffected; the first scoring call for a term re-analyses its reference audio
  more than before.

## Verification

10 new tests, 73/73 overall, typecheck clean. Most of them cover the refusals
rather than the happy path: denied reads report 403, non-redirects and
unreachable media are 502s, a 302 with no `Location` does not resolve to
`undefined`, and a leftover `PLACEHOLDER_AUDIO_URL` is rejected instead of
forwarded.

**Not verified end to end.** Exercising the real path needs a learner session and
a recording against a deployment. The tests prove the resolver; they do not prove
the container is happy with a signed URL. The check after deploy is one
`speakAndScore` exercise — and if it still fails, the response body now names the
cause (403, 502, or the container's own message) instead of a bare 500.

## Merge order

Worth landing before #64. The two are independent — this touches no schema and
#64 touches only the database — but #64 drops the stranded pre-4a rows, which are
currently the only remaining copy of the old content. Better not to discard that
fallback while a learner-facing feature is still unverified.
