### PR TITLE
feat(cms): refuse to delete a term or file something still points at

### DIFF
--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -133,17 +133,25 @@ Format selects. The **preview** button opens the same thing full-width in a new 
 
 ## What you can and cannot do
 
-Two roles.
+All three of us are admins, so in practice: everything. The CMS *has* an editor role — create, edit
+and publish, but not delete or manage accounts — and it is there for whenever somebody joins who
+should not be able to empty the media library. Nobody is on it today.
 
-**Editor** — create, edit and publish everything: lessons, courses, vocabulary, media, resources.
-This is what authoring needs, and it is the default.
+What will stop you is not a permission. **Deleting a word or a file is refused while anything still
+points at it**, and the message names what:
 
-**Admin** — the above, plus deleting content and managing who has an account.
+> The term "kore" is still referenced 2 times. It is used by Lesson 1, Lesson 2. Deleting it would
+> empty those references without any error — remove them first.
 
-If a Delete button refuses, that is the role, not a bug. Deletion is separated out because it is the
-one action with no undo: deleting a word blanks it out of every lesson that referenced it, and
-deleting a media file removes the file itself. Ask an admin, who can also tell you what else pointed
-at the thing.
+That guard exists because the failure it prevents is invisible. Nothing errors when you delete a
+referenced word: every lesson using it keeps working, the word just silently stops appearing,
+because a word reference with no word renders nothing at all. Same for a media file — the file goes,
+and every block pointing at it renders empty. So the check happens before, with a list, rather than
+after, with nothing.
+
+References inside *saved versions* do not block a delete — every draft ever autosaved keeps a copy
+of what it referenced, and enforcing those would make a word undeletable forever. The message
+mentions them so you know they exist.
 
 Everyone who signs in can see the full content and the list of who else has an account.
 

--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -1,6 +1,7 @@
 import type { Access, CollectionConfig } from "payload";
 
 import { isAdmin } from "../access/isAdmin";
+import { guardMediaDelete } from "../hooks/guardReferencedDelete";
 
 /*
  * Uploads. Backed by a **private** Vercel Blob store — see
@@ -126,6 +127,7 @@ export const Media: CollectionConfig = {
    * nothing, across however many lessons referenced it.
    */
   access: { read: readMedia, delete: isAdmin },
+  hooks: { beforeDelete: [guardMediaDelete] },
   upload: {
     mimeTypes: ["image/*", "audio/*", "video/*"],
     /*

--- a/src/payload/collections/Terms.ts
+++ b/src/payload/collections/Terms.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from "payload";
 
 import { audioField, imageField } from "../fields/media";
 import { isAdmin } from "../access/isAdmin";
+import { guardTermDelete } from "../hooks/guardReferencedDelete";
 // Safe as a static import: `utils/kana.ts` is a pure lookup table with no
 // imports of its own, so it does not drag anything into the Payload CLI paths
 // (unlike `@/lib/auth`, which is why Media.ts defers its import to request time).
@@ -247,6 +248,7 @@ export const Terms: CollectionConfig = {
     },
   ],
   hooks: {
+    beforeDelete: [guardTermDelete],
     afterChange: [revalidateTerm],
     afterDelete: [revalidateTermDelete],
     beforeChange: [

--- a/src/payload/hooks/guardReferencedDelete.test.ts
+++ b/src/payload/hooks/guardReferencedDelete.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeRefusal } from "./guardReferencedDelete";
+
+/*
+ * The refusal message is the whole feature. The database will not stop this
+ * delete — the foreign keys are ON DELETE SET NULL — so the only thing between
+ * an editor and a silently emptied reference is this sentence being right.
+ *
+ * Each clause after the first is conditional, and a wrong one misleads rather
+ * than breaks: "referenced 1 times" reads as sloppy, but a version-only count
+ * presented as if it blocked the delete reads as a bug in the guard.
+ */
+
+const base = { owners: [], unattributed: 0, live: 1, inVersions: 0 };
+
+test("names what holds the reference", () => {
+  const msg = describeRefusal('The term "kore"', {
+    ...base,
+    live: 2,
+    owners: ["Lesson 1", "Lesson 2"],
+  });
+  assert.match(msg, /The term "kore" is still referenced 2 times\./);
+  assert.match(msg, /It is used by Lesson 1, Lesson 2\./);
+});
+
+test("singular and plural both read correctly", () => {
+  assert.match(describeRefusal("X", { ...base, live: 1 }), /referenced 1 time\./);
+  assert.match(describeRefusal("X", { ...base, live: 3 }), /referenced 3 times\./);
+});
+
+test("says what to do about it, always", () => {
+  // The actionable half must survive every combination of optional clauses.
+  for (const refs of [
+    base,
+    { ...base, owners: ["Lesson 1"] },
+    { ...base, unattributed: 2 },
+    { ...base, inVersions: 9 },
+  ]) {
+    assert.match(describeRefusal("X", refs), /remove them first/);
+  }
+});
+
+test("untraceable references are counted, not hidden", () => {
+  assert.match(describeRefusal("X", { ...base, unattributed: 1 }), /1 other reference could not be traced/);
+  assert.match(describeRefusal("X", { ...base, unattributed: 4 }), /4 other references could not be traced/);
+});
+
+test("version-only references are mentioned as not blocking", () => {
+  const msg = describeRefusal("X", { ...base, inVersions: 32 });
+  assert.match(msg, /32 more sit in saved versions, which do not block this/);
+});
+
+test("no version references means no parenthetical at all", () => {
+  const msg = describeRefusal("X", { ...base, inVersions: 0 });
+  assert.ok(!msg.includes("saved versions"), msg);
+});
+
+test("owners are omitted rather than left dangling when none resolved", () => {
+  const msg = describeRefusal("X", { ...base, owners: [], unattributed: 1 });
+  assert.ok(!msg.includes("It is used by"), msg);
+});

--- a/src/payload/hooks/guardReferencedDelete.ts
+++ b/src/payload/hooks/guardReferencedDelete.ts
@@ -1,0 +1,83 @@
+import type { CollectionBeforeDeleteHook } from "payload";
+import { APIError } from "payload";
+
+import { findReferences, type References } from "./references";
+
+/*
+ * Refuses to delete a term or a media file that something still points at, with
+ * a message naming what to go and fix.
+ *
+ * The counterpart to `guardLessonDelete`, and deliberately the same shape — but
+ * where that one is the error message for a rule the database already enforces
+ * (`user_progress.lesson_id` is ON DELETE RESTRICT), this one *is* the rule.
+ * Nothing underneath it says no: the foreign keys pointing at `terms` and
+ * `media` are ON DELETE SET NULL, 6 and 55 of them respectively. Postgres will
+ * happily empty every reference and report success.
+ *
+ * That is what makes it worth a hook rather than a role. Deleting a referenced
+ * term does not fail, it *blanks* — a `termRef` with no term renders nothing at
+ * all, on purpose, so a learner never sees a database id. The lesson keeps
+ * working, the word simply stops appearing, and nobody finds out. Gating the
+ * button on being an admin only moves who can cause that; refusing with the
+ * list is what stops it, for everyone.
+ *
+ * ── What it does not block ──────────────────────────────────────────────────
+ *
+ * References that exist only in saved versions. Every draft ever autosaved
+ * keeps a copy of what it referenced, so enforcing those would make a term
+ * undeletable the moment it had ever been used. They are mentioned in the
+ * message instead, because "gone from the current lessons but still in their
+ * history" is a thing worth knowing before you delete.
+ */
+
+/*
+ * The sentence an editor actually reads, kept separate from the query so the
+ * wording can be tested without a database. Every clause after the first is
+ * conditional, and getting one wrong produces a message that is confidently
+ * misleading rather than obviously broken — "referenced 1 times", or a
+ * version-only count presented as if it blocked the delete.
+ */
+export function describeRefusal(subject: string, refs: References): string {
+  const owners = refs.owners.length ? ` It is used by ${refs.owners.join(", ")}.` : "";
+  const rest = refs.unattributed
+    ? ` ${refs.unattributed} other reference${refs.unattributed === 1 ? "" : "s"} could not be traced to a document.`
+    : "";
+  const history = refs.inVersions
+    ? ` (${refs.inVersions} more sit in saved versions, which do not block this.)`
+    : "";
+
+  return (
+    `${subject} is still referenced ${refs.live} ${refs.live === 1 ? "time" : "times"}.` +
+    owners +
+    rest +
+    " Deleting it would empty those references without any error — remove them first." +
+    history
+  );
+}
+
+function guard(collection: "terms" | "media", describe: (doc: Record<string, unknown>) => string) {
+  const hook: CollectionBeforeDeleteHook = async ({ req, id }) => {
+    const doc = (await req.payload.findByID({
+      collection,
+      id,
+      depth: 0,
+      overrideAccess: true,
+    })) as unknown as Record<string, unknown>;
+
+    const refs = await findReferences(collection, id);
+    if (refs.live === 0) return;
+
+    throw new APIError(describeRefusal(describe(doc), refs), 400, undefined, true);
+  };
+  return hook;
+}
+
+export const guardTermDelete = guard("terms", (doc) => {
+  const label = doc.display || doc.key;
+  return label ? `The term "${String(label)}"` : "This term";
+});
+
+export const guardMediaDelete = guard("media", (doc) => {
+  const label = doc.filename;
+  return label ? `"${String(label)}"` : "This file";
+});

--- a/src/payload/hooks/references.ts
+++ b/src/payload/hooks/references.ts
@@ -1,0 +1,245 @@
+import type { SQL } from "drizzle-orm";
+
+/*
+ * "What still points at this?" — for collections the database will not protect.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * Deleting a lesson is safe to get wrong: `user_progress.lesson_id` is an
+ * ON DELETE RESTRICT foreign key, so Postgres refuses and `guardLessonDelete`
+ * turns that refusal into a sentence. Terms and Media have no such backstop.
+ * Measured on the real schema: of the foreign keys pointing at `payload.media`,
+ * 55 are ON DELETE SET NULL, and 6 of those pointing at `payload.terms` are.
+ *
+ * SET NULL is the silent one. Delete a term and every block referencing it
+ * keeps its row, with the reference quietly emptied — a `termRef` then renders
+ * *nothing at all*, which is deliberate (a learner must never see a database
+ * id) and is exactly what makes it impossible to notice. Delete a media file
+ * and the blob goes with it, leaving however many blocks pointing at nothing.
+ *
+ * So this asks the schema, rather than hard-coding a list of places to check.
+ * Which blocks reference a term is a thing that changes every time somebody
+ * adds one, and a hand-maintained list is the kind of second copy that drifts.
+ *
+ * ── What counts as blocking ─────────────────────────────────────────────────
+ *
+ * Only SET NULL references, and only live ones:
+ *
+ *  - CASCADE references are the row's own children (`terms_furigana`,
+ *    `terms_texts`). They are *supposed* to go when it does.
+ *  - Version mirrors (`_lessons_v*`) are history. Blocking on them would make
+ *    a term undeletable forever, since every draft ever saved keeps a copy.
+ *    They are counted and mentioned, not enforced.
+ */
+
+type Fk = { table: string; column: string };
+
+/** Cheap normalisation: neon-http and node-postgres disagree on result shape. */
+function rowsOf(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as Record<string, unknown>[];
+  const rows = (result as { rows?: unknown })?.rows;
+  return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+}
+
+/*
+ * Introspected once per process. The schema only changes on deploy, and a
+ * delete is rare enough that a cold first call costs nothing anybody notices.
+ */
+const fkCache = new Map<string, Fk[]>();
+
+async function setNullReferencesTo(
+  target: string,
+  db: { execute: (q: SQL) => Promise<unknown> },
+  sql: typeof import("drizzle-orm").sql,
+): Promise<Fk[]> {
+  const cached = fkCache.get(target);
+  if (cached) return cached;
+
+  const result = await db.execute(sql`
+    SELECT tc.table_name AS table, kcu.column_name AS column
+      FROM information_schema.referential_constraints rc
+      JOIN information_schema.table_constraints tc
+        ON tc.constraint_name = rc.constraint_name
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = rc.constraint_name
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = rc.constraint_name
+     WHERE ccu.table_schema = 'payload'
+       AND ccu.table_name = ${target}
+       AND rc.delete_rule = 'SET NULL'
+  `);
+
+  const fks = rowsOf(result).map((r) => ({
+    table: String(r.table),
+    column: String(r.column),
+  }));
+  fkCache.set(target, fks);
+  return fks;
+}
+
+/** A version mirror, not live content — Payload names them all with a leading underscore. */
+const isVersionTable = (table: string) => table.startsWith("_");
+
+export type References = {
+  /**
+   * What holds a live reference, named the way an editor would recognise it —
+   * a lesson title, or `the term "sayounara"`. Deduplicated and sorted.
+   */
+  owners: string[];
+  /** Live references that resolved to nothing nameable. Counted, never hidden. */
+  unattributed: number;
+  /** Live references in total. Zero means the delete is safe. */
+  live: number;
+  /** References that live only in saved versions. Reported, never enforced. */
+  inVersions: number;
+};
+
+/**
+ * Everything still pointing at `payload.<target>` row `id`.
+ *
+ * Walks each referencing row up its `_parent_id` / `parent_id` chain looking
+ * for the lesson that owns it — a block row's parent is the lesson, and a
+ * nested block row's parent is the block. Four hops is well past the deepest
+ * shape in this schema; anything that does not resolve is counted rather than
+ * dropped, so the total is always honest even when the attribution is not.
+ */
+export async function findReferences(target: "terms" | "media", id: number | string): Promise<References> {
+  const { db } = await import("../../lib/db");
+  const { sql } = await import("drizzle-orm");
+
+  const fks = await setNullReferencesTo(target, db as never, sql);
+
+  const owners = new Set<string>();
+  let unattributed = 0;
+  let live = 0;
+  let inVersions = 0;
+
+  for (const fk of fks) {
+    const found = rowsOf(
+      await db.execute(
+        sql`SELECT id FROM ${sql.identifier("payload")}.${sql.identifier(fk.table)}
+             WHERE ${sql.identifier(fk.column)} = ${id}`,
+      ),
+    );
+    if (found.length === 0) continue;
+
+    if (isVersionTable(fk.table)) {
+      inVersions += found.length;
+      continue;
+    }
+
+    live += found.length;
+    for (const row of found) {
+      const owner = await ownerFor(fk.table, row.id as string | number, db as never, sql);
+      if (owner) owners.add(owner);
+      else unattributed++;
+    }
+  }
+
+  return { owners: [...owners].sort(), unattributed, live, inVersions };
+}
+
+/** The parent column Payload uses, in the order it uses them. */
+const PARENT_COLUMNS = ["_parent_id", "parent_id"];
+
+/*
+ * Which column leads out of a table, and where to. Cached because the walk
+ * asks per *row*, and without this a media file referenced from fifty places
+ * re-queries information_schema a hundred times — measured at 2.8s for one
+ * delete before this was here.
+ */
+const parentCache = new Map<string, { column: string; table: string } | null>();
+
+async function ownerFor(
+  table: string,
+  rowId: string | number,
+  db: { execute: (q: SQL) => Promise<unknown> },
+  sql: typeof import("drizzle-orm").sql,
+): Promise<string | null> {
+  let currentTable = table;
+  let currentId: string | number = rowId;
+
+  for (let hop = 0; hop < 4; hop++) {
+    if (currentTable === "lessons") {
+      const row = rowsOf(
+        await db.execute(sql`SELECT title FROM payload.lessons WHERE id = ${currentId}`),
+      )[0];
+      const title = row?.title;
+      return typeof title === "string" && title ? title : null;
+    }
+
+    // Media is referenced by terms as well as by lessons — a term's own audio,
+    // image or stroke-order picture. Saying so beats reporting it as a bare
+    // count, because it names the thing the editor has to go and edit.
+    if (currentTable === "terms") {
+      const row = rowsOf(
+        await db.execute(sql`SELECT display, key FROM payload.terms WHERE id = ${currentId}`),
+      )[0];
+      const label = (row?.display || row?.key) as string | undefined;
+      return label ? `the term "${label}"` : null;
+    }
+
+    const parent = await parentOf(currentTable, currentId, db, sql);
+    if (!parent) return null;
+    currentTable = parent.table;
+    currentId = parent.id;
+  }
+  return null;
+}
+
+async function parentOf(
+  table: string,
+  rowId: string | number,
+  db: { execute: (q: SQL) => Promise<unknown> },
+  sql: typeof import("drizzle-orm").sql,
+): Promise<{ table: string; id: string | number } | null> {
+  const cached = parentCache.get(table);
+  if (cached === null) return null;
+  if (cached) {
+    const row = rowsOf(
+      await db.execute(sql`
+        SELECT ${sql.identifier(cached.column)} AS parent_id
+          FROM ${sql.identifier("payload")}.${sql.identifier(table)}
+         WHERE id = ${rowId}
+      `),
+    )[0];
+    const parentId = row?.parent_id;
+    if (parentId === null || parentId === undefined) return null;
+    return { table: cached.table, id: parentId as string | number };
+  }
+
+  for (const column of PARENT_COLUMNS) {
+    const fk = rowsOf(
+      await db.execute(sql`
+        SELECT ccu.table_name AS parent_table
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = tc.constraint_name
+          JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+         WHERE tc.constraint_type = 'FOREIGN KEY'
+           AND tc.table_schema = 'payload'
+           AND tc.table_name = ${table}
+           AND kcu.column_name = ${column}
+         LIMIT 1
+      `),
+    )[0];
+    if (!fk) continue;
+    parentCache.set(table, { column, table: String(fk.parent_table) });
+
+    const row = rowsOf(
+      await db.execute(sql`
+        SELECT ${sql.identifier(column)} AS parent_id
+          FROM ${sql.identifier("payload")}.${sql.identifier(table)}
+         WHERE id = ${rowId}
+      `),
+    )[0];
+    const parentId = row?.parent_id;
+    if (parentId === null || parentId === undefined) return null;
+
+    return { table: String(fk.parent_table), id: parentId as string | number };
+  }
+
+  parentCache.set(table, null);
+  return null;
+}


### PR DESCRIPTION
Builds the thing the delete-role gate was standing in for, so nobody has to be
narrowed to `editor` for the content to be safe.

## Why

Deleting a lesson is already protected: `user_progress.lesson_id` is an ON
DELETE RESTRICT foreign key, so Postgres refuses and `guardLessonDelete` turns
that refusal into a sentence. Terms and Media had no equivalent.

Measured on the real schema — **55** of the foreign keys pointing at
`payload.media` are `ON DELETE SET NULL`, and **6** of those pointing at
`payload.terms`. SET NULL is the silent one: delete a referenced term and
nothing errors, every block keeps its row with the reference quietly emptied,
and a `termRef` with no term renders *nothing at all* — deliberately, so a
learner never sees a database id. The lesson keeps working and the word just
stops appearing.

That is why this is a hook rather than a role. Gating Delete on being an admin
only changes *who* can cause the silent blanking. Refusing with the list is what
prevents it, for everyone, including whoever holds the admin account.

## What it does

```
The term "Are" is still referenced 2 times. It is used by Lesson 2 V1.
Deleting it would empty those references without any error — remove them first.
(4 more sit in saved versions, which do not block this.)
```

```
"Konnnichiha_ibgete.m4a" is still referenced 1 time. It is used by the term
"Konnbannwa". Deleting it would empty those references without any error …
```

`references.ts` asks the schema rather than hard-coding where to look — which
blocks reference a term changes whenever somebody adds one, and a
hand-maintained list is the kind of second copy that drifts. It walks each
referencing row up its `_parent_id`/`parent_id` chain to name the owner, so the
message names a lesson or a term instead of counting rows.

**Saved versions are counted, never enforced.** Every autosaved draft keeps a
copy of what it referenced, so blocking on those would make a term undeletable
the moment it had ever been used.

## Verification

Against `development`, with real content:

- a referenced term → refused, attributed to `Lesson 2 V1`
- a referenced file → refused, attributed to `the term "Konnbannwa"`
- an unreferenced term → still deletes cleanly

80/80 tests, typecheck clean. The message builder is a pure function with 7 of
those tests: every clause after the first is conditional, and a wrong one
misleads ("referenced 1 times", or a version-only count presented as blocking)
rather than obviously breaking.

## Notes

- Also corrects `docs/authoring-guide.md`, which told Sachi a refused Delete
  meant her role. It does not — nobody is moving off admin — and now it usually
  means something still points at the thing.
- Media deletes take ~2.6s while the old block tables are still present, because
  55 tables get probed. That drops sharply once #64 removes 40 of them.
- Independent of #64 and #66; no schema change, no migration.
