### PR TITLE
Refuse an off-site return path after sign-in

### DIFF
--- a/src/lib/return-path.test.ts
+++ b/src/lib/return-path.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { DEFAULT_RETURN_PATH, safeReturnPath } from "./return-path";
+
+test("a same-origin path is returned unchanged", () => {
+  assert.equal(safeReturnPath("/lessons"), "/lessons");
+  assert.equal(safeReturnPath("/lessons/grammar-l1-v1"), "/lessons/grammar-l1-v1");
+  assert.equal(safeReturnPath("/characters/momotaro"), "/characters/momotaro");
+});
+
+test("a query string survives — the proxy sends one", () => {
+  assert.equal(safeReturnPath("/lessons?unit=3"), "/lessons?unit=3");
+  assert.equal(safeReturnPath("/auth?mode=signup"), "/auth?mode=signup");
+});
+
+/*
+ * The reason this module exists. Each of these, handed to `router.push`, is a
+ * hard navigation off-site immediately after a successful sign-in.
+ */
+test("an absolute URL is refused", () => {
+  assert.equal(safeReturnPath("https://evil.com"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("http://evil.com/x"), DEFAULT_RETURN_PATH);
+});
+
+test("a protocol-relative URL is refused", () => {
+  // `//evil.com` is the one that passes a naive `startsWith('/')` check.
+  assert.equal(safeReturnPath("//evil.com"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("//evil.com/path"), DEFAULT_RETURN_PATH);
+});
+
+test("a backslash is refused", () => {
+  assert.equal(safeReturnPath("/\\evil.com"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("\\\\evil.com"), DEFAULT_RETURN_PATH);
+});
+
+test("percent-encoded separators are refused, in either case", () => {
+  assert.equal(safeReturnPath("/%2fevil.com"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("/%2Fevil.com"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("/%5cevil.com"), DEFAULT_RETURN_PATH);
+});
+
+test("a value that is not a path at all is refused", () => {
+  assert.equal(safeReturnPath("lessons"), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath("javascript:alert(1)"), DEFAULT_RETURN_PATH);
+});
+
+test("absent, empty and non-string values take the fallback", () => {
+  assert.equal(safeReturnPath(null), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath(undefined), DEFAULT_RETURN_PATH);
+  assert.equal(safeReturnPath(""), DEFAULT_RETURN_PATH);
+});
+
+test("the fallback is overridable", () => {
+  assert.equal(safeReturnPath("https://evil.com", "/dashboard"), "/dashboard");
+  assert.equal(safeReturnPath(null, "/dashboard"), "/dashboard");
+});

--- a/src/lib/return-path.ts
+++ b/src/lib/return-path.ts
@@ -1,0 +1,39 @@
+/*
+ * Where sign-in sends you afterwards, and why it is validated.
+ *
+ * `src/proxy.ts` bounces a signed-out visitor to `/auth?from=<path>` so they
+ * land back where they were going. That value arrives from the URL bar, so it
+ * is attacker-controlled: `/auth?from=https://evil.com` would otherwise send a
+ * *just-authenticated* user straight off-site, which is the convincing version
+ * of a phishing hop because it happens after a real sign-in on the real domain.
+ *
+ * Better Auth already refuses a `callbackURL` like that server-side
+ * (`originCheckMiddleware` → `isTrustedOrigin`), so the magic-link and Google
+ * paths were covered. The one-time-code and password paths finish on this page
+ * and hand the value to `router.push`, which never reaches that check — so the
+ * value is narrowed here instead, once, at the point it is read. Everything
+ * downstream then gets a path that is already safe.
+ *
+ * The pattern is Better Auth's own rule for a relative path rather than a
+ * hand-rolled one, so the client and the server agree on what is acceptable:
+ * it must start with a single `/`, and it rejects protocol-relative `//host`,
+ * a backslash, and percent-encoded separators. `%` is absent from the path
+ * character class, so anything encoded fails closed to the fallback rather
+ * than being decoded and re-examined.
+ */
+const RELATIVE_PATH = /^\/(?!\/|\\|%2f|%5c)[\w\-.+/@]*(?:\?[\w\-.+/=&%@]*)?$/i;
+
+/** Where a signed-in learner belongs when nothing better is known. */
+export const DEFAULT_RETURN_PATH = "/lessons";
+
+/**
+ * The path to return to after signing in, or `fallback` when the value is
+ * missing or is anything other than a same-origin relative path.
+ */
+export function safeReturnPath(
+  value: string | null | undefined,
+  fallback: string = DEFAULT_RETURN_PATH
+): string {
+  if (typeof value !== "string" || value === "") return fallback;
+  return RELATIVE_PATH.test(value) ? value : fallback;
+}

--- a/src/pages-client/AuthForm.tsx
+++ b/src/pages-client/AuthForm.tsx
@@ -39,6 +39,7 @@ import {
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { useRouter, useSearchParams } from "next/navigation";
 import { emailOtp, signIn } from "../lib/auth-client";
+import { safeReturnPath } from "../lib/return-path";
 import AuthCat from "../components/AuthCat";
 import GoogleMark from "../components/GoogleMark";
 
@@ -66,8 +67,16 @@ export default function AuthForm(): React.ReactElement {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // Where the proxy wanted the user to end up before it bounced them here.
-  const from = searchParams.get("from") || "/lessons";
+  /*
+   * Where the proxy wanted the user to end up before it bounced them here.
+   *
+   * Narrowed to a relative path at the point it is read, so every use below is
+   * already safe: the two `router.push(from)` calls finish on this page and
+   * never reach Better Auth's own server-side `callbackURL` check, which is
+   * what an off-site value would otherwise sail straight through. See
+   * `lib/return-path.ts`.
+   */
+  const from = safeReturnPath(searchParams.get("from"));
 
   /*
    * Better Auth redirects a failed magic-link verification back here with


### PR DESCRIPTION
Security fix. Small and self-contained — worth merging ahead of #71.

## The bug

`src/proxy.ts` bounces a signed-out visitor to `/auth?from=<path>` so they land back where they were going. `AuthForm` used that value unchecked:

```
/auth?from=https://evil.com  →  router.push(from)  →  hard navigation off-site
```

Better Auth validates `callbackURL` server-side (`originCheckMiddleware` → `isTrustedOrigin`), so **magic-link and Google were already covered**. The one-time-code and password paths finish on the page itself and hand the value to `router.push`, which never reaches that check.

That's the convincing shape of a phishing hop — it happens *after* a real sign-in, on the real domain, so the user has no reason to distrust where they end up. `//evil.com` worked too: it's the case a naive `startsWith('/')` test lets through, the same trap `isPreviewablePath` was already written to avoid on the preview route.

## The fix

`from` is narrowed once, where it's read, so all five downstream uses (two `router.push`, three `callbackURL`) get an already-safe value rather than each call site having to remember.

The pattern is Better Auth's own rule for a relative path, so client and server agree on what's acceptable. `%` is absent from the path character class, so anything percent-encoded fails closed to the fallback instead of being decoded and re-examined.

## Verified

End to end through the one-time-code path — the vulnerable one — with a real sign-in each time:

| `?from=` | Lands on | |
|---|---|---|
| `https://attacker.example.com` | `/lessons` | attack blocked, safe fallback |
| `/profile` | `/profile` | legitimate return still works |

(Used an IANA-reserved domain so nothing external is contacted even if the fix had failed.)

- [x] 9 unit tests: absolute, protocol-relative, backslash, percent-encoded (both cases), non-path, null/empty, overridable fallback
- [x] `npm run typecheck` clean, `npm test` 89/89

## Also audited

The other redirect sinks, while here: `/api/preview` already gates on `isPreviewablePath`, and `Home.tsx` takes hardcoded arguments from its callers. `AuthForm` was the only unvalidated one.

## Not in this PR

Three related-but-not-security gaps in the same `from` chain, all of which just *lose* the destination rather than leak it: `proxy.ts` sends `pathname` without the query string; `errorCallbackURL: "/auth"` drops `from` on a retry; and `(public-only)/layout.tsx` hardcodes `/lessons`. Happy to follow up — kept out so this stays a reviewable security change.