### PR TITLE
Pin pg sslmode to verify-full before v9 drops hostname checks

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,13 +1,17 @@
 import { defineConfig } from "drizzle-kit";
 import { config } from "dotenv";
 
+import { pinSslMode } from "./src/lib/db/connection";
+
 config({ path: ".env.local" });
 
 export default defineConfig({
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
-  dbCredentials: { url: process.env.DATABASE_URL! },
+  dbCredentials: {
+    url: process.env.DATABASE_URL ? pinSslMode(process.env.DATABASE_URL) : "",
+  },
   // Payload owns the `payload` schema in the same database (spike #10).
   // `public` is already the default; naming it makes the boundary explicit and
   // keeps drizzle-kit from ever diffing Payload's tables.

--- a/scripts/content/roundtrip.sh
+++ b/scripts/content/roundtrip.sh
@@ -191,15 +191,21 @@ DATABASE_URL="$DB_URL" npm run payload:migrate
 # fail with its own explanation instead, which says the same thing.
 if [ "$OWNED" = true ]; then
   say "Clearing copied learner progress on '$BRANCH'"
-  DATABASE_URL="$DB_URL" node -e '
-    const { Client } = require("pg");
-    (async () => {
-      const c = new Client({ connectionString: process.env.DATABASE_URL });
+  DATABASE_URL="$DB_URL" node --import tsx/esm -e '
+    import { Client } from "pg";
+    import { pinSslMode } from "./src/lib/db/connection.ts";
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL is not set");
+    const c = new Client({ connectionString: pinSslMode(url) });
+    try {
       await c.connect();
       const r = await c.query("DELETE FROM public.user_progress");
       console.log(`  removed ${r.rowCount} progress row(s) — this is a fork, not the original`);
       await c.end();
-    })().catch((e) => { console.error(e.message); process.exit(1); });
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : e);
+      process.exit(1);
+    }
   '
 fi
 

--- a/scripts/migrate/05-media-inventory.ts
+++ b/scripts/migrate/05-media-inventory.ts
@@ -19,6 +19,8 @@
 import { config } from "dotenv";
 import { Pool } from "pg";
 
+import { pinSslMode } from "../../src/lib/db/connection";
+
 // `quiet` keeps dotenv's banner off stdout — this script's stdout IS the report.
 config({ path: ".env.local", quiet: true });
 
@@ -57,7 +59,7 @@ async function main() {
   if (!process.env.DATABASE_URL) {
     throw new Error("DATABASE_URL is not set — see .env.example");
   }
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const pool = new Pool({ connectionString: pinSslMode(process.env.DATABASE_URL) });
 
   try {
     const { rows: columns } = await pool.query<Column>(COLUMN_QUERY);

--- a/scripts/migrate/06-cloudinary-to-blob.ts
+++ b/scripts/migrate/06-cloudinary-to-blob.ts
@@ -35,6 +35,8 @@ import { resolve } from "node:path";
 import { config } from "dotenv";
 import { Pool } from "pg";
 
+import { pinSslMode } from "../../src/lib/db/connection";
+
 config({ path: ".env.local" });
 
 import type { Payload } from "payload";
@@ -196,7 +198,7 @@ async function main() {
     );
   }
 
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const pool = new Pool({ connectionString: pinSslMode(process.env.DATABASE_URL) });
   const { getPayload } = await import("payload");
   const { default: configPromise } = await import("../../src/payload.config");
   const payload = await getPayload({ config: configPromise });

--- a/scripts/payload/check-richtext-backfill.ts
+++ b/scripts/payload/check-richtext-backfill.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 import { Pool } from "pg";
 
 import { textToLexical } from "../../src/lib/content/textToLexical";
+import { pinSslMode } from "../../src/lib/db/connection";
 
 /** Mirrors PROSE_COLUMNS in the migration. Kept beside it deliberately: if the
  *  two disagree, this reports a column the migration did not convert. */
@@ -89,7 +90,9 @@ const keyOf = (table: string, column: string) => `${table}.${column}`;
 
 async function main() {
   const mode = process.argv.includes("--after") ? "after" : "before";
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL is not set — see .env.example");
+  const pool = new Pool({ connectionString: pinSslMode(url) });
 
   const dataType = async (table: string, column: string): Promise<string | null> => {
     const { rows } = await pool.query<{ data_type: string }>(

--- a/src/lib/db/connection.test.ts
+++ b/src/lib/db/connection.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { pinSslMode } from "./connection";
+
+const neon = (sslmode: string) =>
+  `postgresql://user:secret@ep-x.neon.tech/neondb?sslmode=${sslmode}&channel_binding=require`;
+
+test("require becomes verify-full, other query params stay", () => {
+  assert.equal(
+    pinSslMode(neon("require")),
+    neon("verify-full"),
+  );
+});
+
+test("prefer and allow become verify-full", () => {
+  assert.equal(pinSslMode(neon("prefer")), neon("verify-full"));
+  assert.equal(pinSslMode(neon("allow")), neon("verify-full"));
+});
+
+test("the mode is matched case-insensitively", () => {
+  assert.equal(pinSslMode(neon("REQUIRE")), neon("verify-full"));
+});
+
+test("a URL with no sslmode is unchanged, including the local default", () => {
+  const local = "postgresql://localhost:5432/cornerstone_dev";
+  assert.equal(pinSslMode(local), local);
+});
+
+test("verify-full, verify-ca, and disable are left alone", () => {
+  assert.equal(pinSslMode(neon("verify-full")), neon("verify-full"));
+  assert.equal(pinSslMode(neon("verify-ca")), neon("verify-ca"));
+  assert.equal(pinSslMode(neon("disable")), neon("disable"));
+});
+
+test("a percent-encoded password is not round-tripped through URL", () => {
+  const input =
+    "postgresql://user:p%40ss@host/db?sslmode=require&channel_binding=require";
+  assert.equal(
+    pinSslMode(input),
+    "postgresql://user:p%40ss@host/db?sslmode=verify-full&channel_binding=require",
+  );
+});
+
+test("an unparseable string is returned unchanged", () => {
+  assert.equal(pinSslMode("not a url"), "not a url");
+});

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -1,0 +1,38 @@
+/*
+ * Leaf module: imported by `payload.config.ts`, which the Payload CLI loads
+ * in plain Node, so this file must not pull in `server-only` or `src/lib/db`.
+ *
+ * Neon emits `sslmode=require`. Under `pg` 8 that is an alias for
+ * `verify-full` (chain plus hostname). Under `pg` 9 / `pg-connection-string`
+ * v3 it becomes libpq's `require`: encrypted, not verified. Pinning the
+ * current behaviour in code, not in the connection strings, because those
+ * come from Neon and the Vercel integration re-injects them on every deploy.
+ *
+ * `channel_binding=require` on those same URLs does not cover us. `pg` only
+ * offers SCRAM-SHA-256-PLUS when `enableChannelBinding` is set on the client,
+ * and nothing here sets it. Turning that on is a separate change.
+ */
+
+const WEAKER = new Set(["allow", "prefer", "require"]);
+
+/**
+ * Raise `sslmode` to `verify-full` when the URL already asks for TLS but
+ * names a weaker mode. A URL with no `sslmode` is left alone so a local
+ * `postgresql://localhost` string still works without TLS.
+ */
+export function pinSslMode(connectionString: string): string {
+  let url: URL;
+  try {
+    url = new URL(connectionString);
+  } catch {
+    return connectionString;
+  }
+
+  const mode = url.searchParams.get("sslmode");
+  if (mode === null) return connectionString;
+  if (!WEAKER.has(mode.toLowerCase())) return connectionString;
+
+  // Rewrite only this query value so a password's encoding is not
+  // round-tripped through `URL.toString()`.
+  return connectionString.replace(/([?&])sslmode=[^&]*/i, "$1sslmode=verify-full");
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -2,6 +2,7 @@ import { drizzle as drizzleNeon } from "drizzle-orm/neon-http";
 import { drizzle as drizzleNode } from "drizzle-orm/node-postgres";
 import { neon } from "@neondatabase/serverless";
 import { Pool } from "pg";
+import { pinSslMode } from "./connection";
 import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL;
@@ -20,6 +21,6 @@ const isNeon = /\.neon\.tech|neon\.build/.test(connectionString);
 
 export const db = isNeon
   ? drizzleNeon(neon(connectionString), { schema })
-  : drizzleNode(new Pool({ connectionString }), { schema });
+  : drizzleNode(new Pool({ connectionString: pinSslMode(connectionString) }), { schema });
 
 export { schema };

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -15,6 +15,7 @@ import { Lessons } from "./payload/collections/Lessons";
 import { Media } from "./payload/collections/Media";
 import { Resources } from "./payload/collections/Resources";
 import { Terms } from "./payload/collections/Terms";
+import { pinSslMode } from "./lib/db/connection";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -97,7 +98,11 @@ export default buildConfig({
     schemaName: "payload",
     push: false,
     migrationDir: path.resolve(dirname, "payload/migrations"),
-    pool: { connectionString: process.env.DATABASE_URL },
+    pool: {
+      connectionString: process.env.DATABASE_URL
+        ? pinSslMode(process.env.DATABASE_URL)
+        : process.env.DATABASE_URL,
+    },
   }),
   secret: process.env.PAYLOAD_SECRET ?? "",
   typescript: {


### PR DESCRIPTION
## Summary
- Neon emits `sslmode=require`, which `pg` 8 treats as `verify-full`. Under `pg` 9 the same string becomes encrypted-but-unverified. `pinSslMode` in `src/lib/db/connection.ts` raises a present weaker mode to `verify-full` and leaves a URL with no `sslmode` alone, so a local `postgresql://localhost` string still works without TLS.
- Wired into every `pg` Pool: Payload's adapter, the node-postgres Drizzle branch, drizzle-kit, the three one-off scripts, and `content:roundtrip`. Connection strings stay as Neon issued them.

Closes #75.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (96/96)
- [x] `npm run payload:migrate:status` — no `SECURITY WARNING`
- [x] `npm run parity http://localhost:3000` — 40/40 + 5/5 CMS
- [ ] Confirm a `pg` 8 parse of an unpinned `sslmode=require` URL still prints the warning, and the pinned URL does not (`pg-connection-string`'s `parse()`)