### PR TITLE
Remove the neondatabase placeholder package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "graphql": "^16.14.2",
         "lucide-react": "^0.541.0",
         "mongodb": "^7.5.0",
-        "neondatabase": "^0.0.1-security",
         "next": "^16.3.0",
         "payload": "3.88.0",
         "pg": "^8.23.0",
@@ -6966,11 +6965,6 @@
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
-    },
-    "node_modules/neondatabase": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/neondatabase/-/neondatabase-0.0.1-security.tgz",
-      "integrity": "sha512-MXrTyyZTjmZy6c3MsLxmsL0G15O4yCyzUks+uPavt8Kch94DZE+RnI28VekwHLqCjk5TYZHVEtGfu5v6097XvA=="
     },
     "node_modules/next": {
       "version": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "graphql": "^16.14.2",
     "lucide-react": "^0.541.0",
     "mongodb": "^7.5.0",
-    "neondatabase": "^0.0.1-security",
     "next": "^16.3.0",
     "payload": "3.88.0",
     "pg": "^8.23.0",


### PR DESCRIPTION
`neondatabase@^0.0.1-security` landed on `main` via #76. It is npm's **security holding** package — a reclaimed name republished with no code in it. npm's own description is literally `security holding package`, and `0.0.1-security` is the only version that has ever been published.

The real client is `@neondatabase/serverless`, already a dependency at `^1.1.0` and the one `src/lib/db/index.ts` actually imports. Nothing in `src/` or `scripts/` imports `neondatabase` — which is exactly why installing it broke nothing, and so gave no signal that it was a typo for the scoped name.

## Why bother, given it's inert

- it ships a dependency nobody reviewed and nothing uses
- `npm ls` and any future `npm audit` misrepresent the dependency tree
- if that name were ever transferred and republished, the next `npm install` pulls unvetted code into the app

## Verified

- [x] No importer anywhere in `src/` or `scripts/`
- [x] `npm run typecheck` clean
- [x] `npm test` 96/96
- [x] Both `package.json` and `package-lock.json` updated