### PR TITLE
Correct guidance docs that contradicted the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,19 @@ mentions left in `src/` are historical comments. Content comes from Payload.
 
 - **Migration order is fixed**: `npm run db:migrate` before `npm run payload:migrate`.
   Payload never issues `CREATE SCHEMA`, so Drizzle has to create `payload` first.
-- **There is no test suite.** A change is verified by `npm run typecheck` plus
-  `npm run parity [url]`, which checks all 40 routes in both auth states and then
-  asserts the CMS is up and serving real content. Both must pass before you call
-  something done.
+- **Four checks, and each proves something different.** All of them pass before you
+  call something done, because none of them subsumes another:
+
+  | Command | Proves | Does not prove |
+  |---|---|---|
+  | `npm run typecheck` | types line up | that anything runs |
+  | `npm test` | pure logic is right | that any page renders |
+  | `npm run parity [url]` | every route's guard and chrome, in both auth states | that content is correct — it reads through `unstable_cache` and has passed a whole pre-migration lesson |
+  | `npm run content:verify` | every media and term reference resolves, uncached | that a page renders |
+
+  `parity` passing is not evidence about content. When a change touches Payload or
+  `content/snapshot/`, `content:verify` is the one that cannot be answered from a
+  stale cache entry. Neither replaces opening the page.
 - **Node 24 LTS**, pinned in `.nvmrc` and floored at 24.11.0 in `engines`. CI
   reads `.nvmrc` via `node-version-file`, so that file is the one to change.
 - `npm run dev` rewrites the managed block at the bottom of this file. Leave it alone

--- a/README.md
+++ b/README.md
@@ -131,10 +131,14 @@ src/features/
 
 `(player)` is a sibling of `(learn)`, not a child. It admits a CMS editor with no learner session, which a `requireSession()` layout would refuse.
 
-Screens live next to their `page.tsx` when they belong to one route, or in
-`src/features/` when they are shared. `src/components/` is Header, Footer,
-SiteChrome, media, richtext, and other pieces more than one feature uses.
-Items marked NEW are product work.
+`src/features/<domain>/` is for a domain that owns more than components — server
+actions, shared types, or a render pipeline its own components dispatch through.
+A screen with no such domain behind it lives next to its `page.tsx`. `src/components/`
+is Header, Footer, SiteChrome, media, richtext, and other cross-domain pieces.
+
+The test is *what the domain owns*, not how many routes use it: every screen in
+`features/account/` is used by exactly one route, and belongs there because the
+domain also owns `actions.ts`. Items marked NEW are product work.
 
 List the route directories with `find src/app -type d | sort`.
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -51,8 +51,8 @@ In this codebase the split is deliberately simple:
 
 ```
 src/app/**/page.tsx                    server — fetches data, passes it down as props
-src/features/**/components/*.tsx       client — screens used by more than one route
-src/app/**/<Name>.tsx                  client — a screen used by that route only
+src/features/<domain>/                 client — a domain that owns more than components
+src/app/**/<Name>.tsx                  client — a screen with no such domain behind it
 src/components/*.tsx                   client — chrome, media, richtext, shared widgets
 ```
 
@@ -230,7 +230,7 @@ Drizzle always migrates first — Payload never issues `CREATE SCHEMA`.
 
 **Change lesson rendering.** `src/components/` — the exercise components are unchanged from the old app. `renderItem()` in `NewLessonPlayer.tsx` maps an item's `type` to a component.
 
-**Check you didn't break anything.** `npm run typecheck`, then `npm run parity` — it verifies every route's guard and chrome against the original app's route table in both auth states, then that the CMS is up and actually serving content. There is no test suite; these two are the check.
+**Check you didn't break anything.** `npm run typecheck`, `npm test`, then `npm run parity` — parity verifies every route's guard and chrome against the original app's route table in both auth states, then that the CMS is up and actually serving content. If you touched Payload or `content/snapshot/`, add `npm run content:verify`: parity reads through `unstable_cache` and can be answered from an entry built before your change, so it is not evidence about content.
 
 ---
 

--- a/docs/orientation.md
+++ b/docs/orientation.md
@@ -100,6 +100,19 @@ with a `page.tsx`. The auth rule lives in that group's `layout.tsx` — open it 
 it rather than assuming. Add the path to `scripts/parity-check.mjs`'s route table in
 the same PR, or nothing is guarding it.
 
+The `page.tsx` is a server component that fetches; the screen it renders is a
+client component, and where that lives depends on **what the domain owns**, not on
+how many routes use it:
+
+| The screen belongs to… | It lives in |
+|---|---|
+| a domain that also owns actions, shared types, or a render pipeline | `src/features/<domain>/components/` |
+| no such domain — just this one route | next to its `page.tsx` |
+| chrome or a cross-domain widget | `src/components/` |
+
+Every screen in `features/account/` is used by exactly one route and still belongs
+there, because the domain owns `actions.ts` too.
+
 **Change a Payload field.** This is a migration, not an edit:
 
 ```bash
@@ -132,7 +145,7 @@ how the `steps` rename shipped without a line of backfill SQL.
 | Command | Proves | Does not prove |
 |---|---|---|
 | `npm run typecheck` | the types line up | that anything runs |
-| `npm test` (89) | the pure logic is right | that any page renders |
+| `npm test` (96) | the pure logic is right | that any page renders |
 | `npm run parity` (40 route checks + 5 CMS) | every route's guard and chrome | that content is correct — it can be answered from cache |
 | `npm run content:verify` | every media and term reference resolves, uncached | that a page renders |
 


### PR DESCRIPTION
Three claims in the docs contradicted the repository. Each one steered whoever read it — human or agent — toward the wrong action, which is worse than silence.

## "There is no test suite"

`AGENTS.md` and `docs/MIGRATION_GUIDE.md` both said it. **There are 96 tests.** The line told agents to skip the check most likely to catch a regression in pure logic.

Replaced with a table of the four checks and what each actually proves, because the real trap is subtler than a missing command: **`parity` reads through `unstable_cache`** and has passed an entire pre-migration lesson. A green parity is not evidence about content — `content:verify` is the one that can't be answered from a stale entry. That distinction has cost time here before and wasn't written down anywhere an agent would find it.

## The `features/` placement rule was falsified by its own tree

README and `MIGRATION_GUIDE` both said `src/features/**/components/` is for *"screens used by more than one route."*

Every screen in `features/account/` is used by **exactly one**:

| | route importers |
|---|---|
| `account/components/Profile.tsx` | 1 |
| `account/components/WelcomeForm.tsx` | 1 |
| `account/components/ForgotPassword.tsx` | 1 |
| `account/components/ResetPassword.tsx` | 1 |

A newcomer applying the documented rule would colocate all of them and produce a tree nobody wanted — the precise failure #77 exists to prevent. `MIGRATION_GUIDE.md` even used `LessonRunner` as its worked example three lines below the rule, and that's a counterexample too.

The rule the tree actually follows is **what the domain owns**: a domain with `actions.ts`, shared types, or a render pipeline gets a folder; a screen with no domain behind it sits next to its `page.tsx`. Stated that way in both files.

Also added it to `docs/orientation.md`'s "Add a page" recipe, which previously stopped at "add a folder with a `page.tsx`" and never said where the client body goes. That gap matters most in the one doc written for the two developers this whole effort is for.

## Stale count

`orientation.md` said 89 tests; #79 added seven.

## Verified

- [x] No occurrence of "no test suite" remains in any doc
- [x] No occurrence of the contradicted placement rule remains
- [x] Importer counts above verified against the tree, not asserted
- [x] `npm run typecheck` clean

Docs only — no source changes.