### PR TITLE
Fix review findings on the kana pairing, lesson completion, and audio lifecycles

### DIFF
--- a/content/snapshot/lessons.json
+++ b/content/snapshot/lessons.json
@@ -197,7 +197,7 @@
           "components": [
             {
               "id": "6a83f02bb78e2c76b66a8656",
-              "instructions": "Match each hiragana to its katakana",
+              "instructions": "Match each audio clip to its hiragana",
               "pairing": "kana",
               "blockName": null,
               "blockType": "matchPairs",
@@ -829,7 +829,7 @@
           "components": [
             {
               "id": "6a83f02cb78e2c76b66a866f",
-              "instructions": "Match each hiragana to its katakana",
+              "instructions": "Match each audio clip to its hiragana",
               "pairing": "kana",
               "blockName": null,
               "blockType": "matchPairs",

--- a/docs/content-backlog.md
+++ b/docs/content-backlog.md
@@ -123,8 +123,8 @@ The five kana sets are the biggest block of it:
 
 | Terms with no audio | Where it shows |
 |---|---|
-| `あ-ア` `い-イ` `う-ウ` `え-エ` `お-オ` | 5 listening exercises in `hiragana-l1-v1-hokkaido` |
-| `か-カ` `き-キ` `く-ク` `け-ケ` `こ-コ` | 5 listening exercises in `hiragana-l2-v1-iwate` |
+| `あ-ア` `い-イ` `う-ウ` `え-エ` `お-オ` | 5 listening exercises **and the kana matching screen** in `hiragana-l1-v1-hokkaido` |
+| `か-カ` `き-キ` `く-ク` `け-ケ` `こ-コ` | 5 listening exercises **and the kana matching screen** in `hiragana-l2-v1-iwate` |
 | `desu` `desu-ka` | 2 in `grammar-l1-v2` |
 | `sumimasen-wakarimasen`, `mouichido-onegaishimasu`, `yukkuri-onegaishimasu`, `kore`, `sore`, `are`, `dore`, `kore-ha-nandesuka`, `sore-ha-nandesuka` | the rest, in `grammar-l2-v1` |
 
@@ -132,10 +132,18 @@ A recording on the term fixes every exercise that references it at once — that
 the vocabulary collection. Upload the clip to the term's own Audio field in the CMS
 (Vocabulary → the word → Audio); nothing else needs touching.
 
+The two kana matching screens are new to that list. `matchPairs` with `pairing: "kana"` used to pair
+a term's hiragana with its katakana; katakana is withheld for now, so it pairs the term's *recording*
+with its hiragana instead. That makes the clip the left-hand card rather than a bonus on it: a term
+without one is an unlabelled greyed-out speaker, and five of those in a column is a screen with
+nothing to tell the rows apart. Those pairs are dropped, which leaves both screens with fewer than
+two pairs, so neither renders at all until the ten clips land.
+
 Separately, **11 speaking exercises have no reference audio**, so a learner can record themselves
 but nothing can be scored. Same fix, same field.
 
-`npm run content:verify` prints both counts on their own lines, so they go down as recordings land.
+`npm run content:verify` prints each of these counts on its own line, so they go down as recordings
+land.
 
 ---
 

--- a/scripts/content/migrate-to-library.ts
+++ b/scripts/content/migrate-to-library.ts
@@ -493,15 +493,28 @@ function convert(block: Block, ctx: Context): Block[] {
         ctx.quarantine(`kana pairs with no catalogue term: ${missing.join(", ")}`);
         return [];
       }
-      const withoutKatakana = found.filter((t) => !t?.katakana).map((t) => t?.key ?? "?");
-      if (withoutKatakana.length) {
-        ctx.quarantine(`pairs hiragana with katakana, but these terms have no katakana: ${withoutKatakana.join(", ")}`);
-        return [];
-      }
+      /*
+       * No katakana gate any more. "kana" pairs the term's audio with its
+       * hiragana now (katakana is withheld — see RenderBlock's MatchPairsView),
+       * so a missing katakana form no longer stops the exercise from playing,
+       * and quarantining on it would hold back cards that work.
+       *
+       * The recording it needs instead is not checked here: `adopt` attaches
+       * audio to catalogue terms as it walks the snapshot, so at this point in
+       * the run a term may simply not have reached the block that gives it one.
+       * That check belongs to `content:verify`, which reads the finished
+       * content — the same division of labour as the katakana check it replaces.
+       */
       return [
         {
+          /*
+           * The authored prompt is deliberately dropped rather than carried
+           * across. Every one of these was written for "match each hiragana to
+           * its katakana", which is not the exercise this becomes; keeping it
+           * would put a confidently wrong instruction above an audio screen.
+           */
           blockType: "matchPairs",
-          instructions: block.prompt ?? "Match each hiragana to its katakana",
+          instructions: "Match each audio clip to its hiragana",
           terms: found.map((t) => ref(t!.key)),
           pairing: "kana",
         },

--- a/scripts/content/verify.ts
+++ b/scripts/content/verify.ts
@@ -200,16 +200,16 @@ async function main() {
       /*
        * Katakana is withheld for the moment: "kana" now pairs a term's audio
        * (left, no label) with its hiragana form (right) — see RenderBlock's
-       * MatchPairsView. Audio is not required here the way it is for the
-       * "audio" pairing: a missing recording renders a greyed-out filler
-       * button (the same convention MatchDotsMedia and FlashcardReview use)
-       * rather than dropping the pair, so it is reported as a to-do below,
-       * not folded into `missing`.
+       * MatchPairsView. That makes the recording as load-bearing here as it is
+       * for the "audio" pairing, and more so than a missing gloss: the left
+       * card *is* the clip, so a term without one is an unlabelled greyed-out
+       * speaker that nothing distinguishes from the next one. RenderBlock
+       * drops those pairs, so they belong in `missing` alongside the rest.
        */
       const missing = list.filter((t) => {
         if (pairing === "meaning") return !t.meaning;
         if (pairing === "reading") return !t.reading && !t.romaji;
-        if (pairing === "audio") return !t.audio;
+        if (pairing === "audio" || pairing === "kana") return !t.audio;
         return false;
       });
 
@@ -228,20 +228,6 @@ async function main() {
           where,
           detail: `only ${list.length - missing.length} usable pair(s) — a matching exercise needs two`,
         });
-      }
-
-      if (pairing === "kana") {
-        const noAudio = list.filter((t) => !t.audio);
-        if (noAudio.length) {
-          todos.push({
-            doc,
-            where,
-            detail:
-              `pairing is "kana" but ${noAudio.length} of ${list.length} term(s) have no recording ` +
-              `yet (${noAudio.map((t) => String(t.key)).join(", ")}) — the left card shows a filler ` +
-              "audio button until one is added.",
-          });
-        }
       }
     }
 

--- a/scripts/content/verify.ts
+++ b/scripts/content/verify.ts
@@ -74,6 +74,8 @@ async function main() {
   const todos: Problem[] = [];
   /** Listening exercises with nothing to play. Counted on its own line. */
   const silentListening: Problem[] = [];
+  /** "kana" matching screens whose left cards have no clip. Likewise. */
+  const silentKana: Problem[] = [];
   let resolved = 0;
   let termRefs = 0;
   let empty = 0;
@@ -200,16 +202,21 @@ async function main() {
       /*
        * Katakana is withheld for the moment: "kana" now pairs a term's audio
        * (left, no label) with its hiragana form (right) — see RenderBlock's
-       * MatchPairsView. That makes the recording as load-bearing here as it is
-       * for the "audio" pairing, and more so than a missing gloss: the left
-       * card *is* the clip, so a term without one is an unlabelled greyed-out
-       * speaker that nothing distinguishes from the next one. RenderBlock
-       * drops those pairs, so they belong in `missing` alongside the rest.
+       * MatchPairsView. The left card *is* the clip, so a term without one is
+       * an unlabelled greyed-out speaker with nothing to tell it apart from the
+       * next one — RenderBlock drops those pairs rather than render a screen
+       * that cannot be solved.
+       *
+       * Not a structural failure, though, for the same reason `listenAndChoose`
+       * is not: what a "kana" pair needs *structurally* is the written form on
+       * its right, and every term has one. The recording is an editorial gap,
+       * and the fix is ten of them rather than a code change. It gets its own
+       * counted line below instead of being lost among the to-dos.
        */
       const missing = list.filter((t) => {
         if (pairing === "meaning") return !t.meaning;
         if (pairing === "reading") return !t.reading && !t.romaji;
-        if (pairing === "audio" || pairing === "kana") return !t.audio;
+        if (pairing === "audio") return !t.audio;
         return false;
       });
 
@@ -228,6 +235,23 @@ async function main() {
           where,
           detail: `only ${list.length - missing.length} usable pair(s) — a matching exercise needs two`,
         });
+      }
+
+      if (pairing === "kana") {
+        const noAudio = list.filter((t) => !t.audio);
+        if (noAudio.length) {
+          const left = list.length - noAudio.length;
+          silentKana.push({
+            doc,
+            where,
+            detail:
+              `${noAudio.length} of ${list.length} term(s) have no recording ` +
+              `(${noAudio.map((t) => String(t.key)).join(", ")}) — those pairs are dropped, ` +
+              (left < 2
+                ? `leaving ${left}, so the screen renders nothing at all.`
+                : `leaving ${left}.`),
+          });
+        }
       }
     }
 
@@ -391,6 +415,17 @@ async function main() {
     );
     for (const s of silentListening.slice(0, 6)) console.log(`      ${s.doc}  ${s.where}  ${s.detail}`);
     if (silentListening.length > 6) console.log(`      … and ${silentListening.length - 6} more`);
+  }
+
+  if (silentKana.length) {
+    console.log(
+      `\n  ⚠ ${silentKana.length} "kana" matching screen(s) are short of recordings — the left\n` +
+        `    card of that pairing is the clip itself, so a term without one is dropped. Not counted\n` +
+        `    as a structural failure, on the same grounds as the listening exercises above: the fix\n` +
+        `    is recordings, not a code change. A screen left with fewer than two pairs renders\n` +
+        `    nothing — see docs/content-backlog.md.`
+    );
+    for (const s of silentKana) console.log(`      ${s.doc}  ${s.where}\n        ${s.detail}`);
   }
 
   if (todos.length) {

--- a/src/app/(app)/(player)/lessons/[slug]/review/page.tsx
+++ b/src/app/(app)/(player)/lessons/[slug]/review/page.tsx
@@ -1,13 +1,14 @@
 import { redirect } from "next/navigation";
 
-import { getLessonBySlug } from "@/lib/content/content";
+import { getDraftLesson, getLessonBySlug } from "@/lib/content/content";
+import { getPreviewEditor } from "@/lib/session";
 import { collectLessonTerms } from "@/lib/content/lessonTerms";
 import TermReviewPage from "@/features/learning/components/TermReviewPage";
 
 /*
  * Every term a lesson taught, on one page — a study aid rather than a graded
- * screen, so it reads published content directly the same way the player
- * does rather than needing its own progress-aware plumbing.
+ * screen, so it reads the lesson the same way the player does rather than
+ * needing its own progress-aware plumbing.
  */
 export default async function Page({
   params,
@@ -16,7 +17,16 @@ export default async function Page({
 }) {
   const { slug } = await params;
 
-  const lesson = await getLessonBySlug(slug);
+  /*
+   * The same preview branch the lesson route has. Without it an editor who
+   * reached the review link from Live Preview on an unpublished lesson was
+   * bounced to /dashboard — the one page that cannot show them what they are
+   * writing. Draft access is still decided by `getPreviewEditor`, which only
+   * answers for a request that came through /api/preview as a `cms_admins`
+   * user; everything else reads published content.
+   */
+  const editor = await getPreviewEditor();
+  const lesson = editor ? await getDraftLesson(slug, editor) : await getLessonBySlug(slug);
   if (!lesson) redirect("/dashboard");
 
   const terms = collectLessonTerms(lesson);

--- a/src/features/exercises/components/DragDropCombination.tsx
+++ b/src/features/exercises/components/DragDropCombination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, IconButton, Typography } from "@mui/material";
 import VolumeUpRoundedIcon from "@mui/icons-material/VolumeUpRounded";
 import GraphicEqRoundedIcon from "@mui/icons-material/GraphicEqRounded";
@@ -62,7 +62,10 @@ const DragDropCombination: React.FC<Props> = ({
   // the whole-word clip and the per-tile clips are gated the same way.
   const showResult = checked && isCorrect;
   const showAudio = showResult && Boolean(audioUrl);
-  const showTileAudio = showResult && Boolean(tileAudio?.length);
+  // `tileAudio` has one entry per tile whether or not that tile has a clip, so
+  // its length says nothing — an all-undefined array would still put "Hear each
+  // piece" above a row of inert grey buttons.
+  const showTileAudio = showResult && Boolean(tileAudio?.some(Boolean));
 
   const bankIndices = options.map((_, i) => i).filter((i) => !placedIndices.includes(i));
 
@@ -172,6 +175,11 @@ const DragDropCombination: React.FC<Props> = ({
     setPlayingTile(index);
     audio.play().catch(() => setPlayingTile(null));
   };
+
+  // `playTile` builds a detached `Audio` rather than rendering an element, so
+  // unmounting this exercise does not stop it the way removing the <audio>
+  // below does — without this, a tile plays on over the next screen.
+  useEffect(() => () => tileAudioRef.current?.pause(), []);
 
   const shouldShowImage = Boolean(resolvedImageUrl && !imageFailed);
 

--- a/src/features/exercises/components/MatchDots.tsx
+++ b/src/features/exercises/components/MatchDots.tsx
@@ -31,6 +31,7 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, heading, onResult, keepLeftO
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dotRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const [firstId, setFirstId] = useState<string | null>(null);
   const [connections, setConnections] = useState<Connection[]>([]);
@@ -38,13 +39,27 @@ const DotMatch: React.FC<DotMatchProps> = ({ pairs, heading, onResult, keepLeftO
   const [correctSet, setCorrectSet] = useState<Set<string>>(new Set());
   const [playingIndex, setPlayingIndex] = useState<number | null>(null);
 
+  /*
+   * One clip at a time. Each left card builds its own detached `Audio`, so two
+   * cards clicked in quick succession would play over each other — on the one
+   * exercise whose whole task is telling recordings apart. `onerror` is the
+   * same concern: a clip that dies mid-stream never fires `onended`, which
+   * would leave the equalizer icon running on a row that has gone silent.
+   */
   const playAudio = (index: number, src?: string) => {
     if (!src) return;
+    audioRef.current?.pause();
     const audio = new Audio(src);
+    audioRef.current = audio;
     setPlayingIndex(index);
     audio.onended = () => setPlayingIndex(null);
+    audio.onerror = () => setPlayingIndex(null);
     audio.play().catch(() => setPlayingIndex(null));
   };
+
+  // Detached again, so unmounting the exercise has to stop it explicitly or
+  // the clip carries on over the next screen.
+  useEffect(() => () => audioRef.current?.pause(), []);
 
   // Randomized once per mount so the layout is fresh on every attempt
   // (except the left column when keepLeftOrder is set — see buildArrangement).

--- a/src/features/exercises/components/RenderBlock.tsx
+++ b/src/features/exercises/components/RenderBlock.tsx
@@ -418,15 +418,16 @@ const MatchPairsView: React.FC<MatchPairsBlock & { onResult?: ResultCallback }> 
      * failure rather than leaving it to be noticed by a learner.
      *
      * The "kana" pairing has an empty `hiragana` by design (its left card is
-     * audio-only), so it only drops pairs missing the written form. A missing
-     * recording renders the card's filler audio button instead — the same
-     * placeholder MatchDotsMedia and FlashcardReview already use — rather than
-     * dropping the pair outright, since the point of this exercise is the
-     * written form, not the recording.
+     * audio-only), which makes the recording load-bearing rather than
+     * decorative: the clip *is* the left card. A term without one renders a
+     * greyed-out speaker with no label, and a second such term renders an
+     * identical one — nothing distinguishes the rows, so the learner cannot
+     * solve the screen rather than merely getting less out of it. Dropped for
+     * the same reason an identical pair is, and reported by `content:verify`.
      */
     .filter((pair) =>
       pairing === "kana"
-        ? pair.katakana !== ""
+        ? pair.katakana !== "" && Boolean(pair.audio)
         : pair.hiragana !== "" && pair.katakana !== "" && pair.hiragana !== pair.katakana
     );
 
@@ -435,10 +436,22 @@ const MatchPairsView: React.FC<MatchPairsBlock & { onResult?: ResultCallback }> 
   // a broken one, with the report coming from `content:verify`.
   if (pairs.length < 2) return null;
 
+  /*
+   * `DotMatch` defaults its heading to the kana wording it was written for,
+   * which is wrong for the two pairings that also reach it. Blank instructions
+   * get the heading for the pairing on screen instead of that one sentence.
+   */
+  const defaultHeading =
+    pairing === "kana"
+      ? "Match each audio clip to its hiragana"
+      : pairing === "reading"
+        ? "Match each word to its reading"
+        : "Match each word to its meaning";
+
   return (
     <DotMatch
       pairs={pairs}
-      heading={instructions ?? undefined}
+      heading={instructions?.trim() || defaultHeading}
       onResult={onResult}
       keepLeftOrder={pairing === "kana"}
     />

--- a/src/features/learning/components/LessonRunner.tsx
+++ b/src/features/learning/components/LessonRunner.tsx
@@ -67,6 +67,58 @@ import { collectLessonTerms } from "@/lib/content/lessonTerms";
  * reads, and "after the deck" was a position no one chose.
  */
 
+/*
+ * The review screen is the last step and this link is the only thing on it, so
+ * a learner who takes it never reaches "Finish" — which is where the lesson
+ * gets marked completed. Navigating straight away raced that write and usually
+ * lost it, leaving a finished lesson sitting "in progress" on /lessons; the
+ * save is awaited here for the same reason `advance` awaits it on the last step.
+ */
+const ReviewTermsButton: React.FC<{
+  href: string;
+  complete: React.RefObject<(() => Promise<boolean>) | null>;
+}> = ({ href, complete }) => {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const handleClick = async (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    if (busy) return;
+
+    setBusy(true);
+    // The runner fills this in on mount, so it is set long before the last
+    // step can be reached; unset, the link is just a link. In the CMS preview
+    // it resolves true without writing — `upsertProgress` reports an editor
+    // with no learner session as ok-but-unsaved.
+    const ok = (await complete.current?.()) ?? true;
+    setBusy(false);
+
+    // Stay put on a failed write. The runner's banner is already up and offers
+    // the retry, and leaving now would lose the completion silently.
+    if (!ok) return;
+    router.push(href);
+  };
+
+  return (
+    <Button
+      component={Link}
+      href={href}
+      onClick={handleClick}
+      disabled={busy}
+      variant="outlined"
+      sx={{
+        borderRadius: 999,
+        fontWeight: 700,
+        borderColor: "#B43D20",
+        color: "#B43D20",
+        "&:hover": { borderColor: "#9D351C", bgcolor: "rgba(180,61,32,0.06)" },
+      }}
+    >
+      Review terms
+    </Button>
+  );
+};
+
 /** One authored row of `lesson.steps`. */
 type AuthoredStep = NonNullable<Lesson["steps"]>[number];
 
@@ -100,7 +152,11 @@ function blockTypes(step: AuthoredStep): string[] {
   return (step.components ?? []).map((block) => block.blockType);
 }
 
-function buildSteps(lesson: Lesson, seed: string): Step[] {
+function buildSteps(
+  lesson: Lesson,
+  seed: string,
+  complete: React.RefObject<(() => Promise<boolean>) | null>
+): Step[] {
   const authored = shuffleSteps(lesson.steps ?? [], {
     seed,
     // The field has existed since the import and nothing has ever read it.
@@ -164,42 +220,35 @@ function buildSteps(lesson: Lesson, seed: string): Step[] {
 
   // Last screen before Finish: every word and character this lesson taught,
   // with audio and a place to record yourself — a study aid, not a step of
-  // its own, so it carries no grading and nothing to save progress against.
-  steps.push(
-    chrome("lesson:review", "Review", (
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          textAlign: "center",
-          gap: 2,
-          py: 2,
-        }}
-      >
-        <MenuBookRoundedIcon sx={{ fontSize: "2.5rem", color: "#B43D20" }} />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.1rem" }}>Nice work!</Typography>
-        <Typography sx={{ color: "text.secondary", maxWidth: 360 }}>
-          Review every word and character from this lesson — with audio, playback speed,
-          and a place to record yourself.
-        </Typography>
-        <Button
-          component={Link}
-          href={lessonReviewHref(lesson.slug)}
-          variant="outlined"
+  // its own, so it carries no grading of its own.
+  //
+  // Skipped when the lesson references no terms at all. The screen is one
+  // sentence and a link, and the page behind that link would only say "This
+  // lesson has no terms to review yet" — an offer worth not making.
+  if (lessonTerms.length) {
+    steps.push(
+      chrome("lesson:review", "Review", (
+        <Box
           sx={{
-            borderRadius: 999,
-            fontWeight: 700,
-            borderColor: "#B43D20",
-            color: "#B43D20",
-            "&:hover": { borderColor: "#9D351C", bgcolor: "rgba(180,61,32,0.06)" },
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 2,
+            py: 2,
           }}
         >
-          Review terms
-        </Button>
-      </Box>
-    ))
-  );
+          <MenuBookRoundedIcon sx={{ fontSize: "2.5rem", color: "#B43D20" }} />
+          <Typography sx={{ fontWeight: 800, fontSize: "1.1rem" }}>Nice work!</Typography>
+          <Typography sx={{ color: "text.secondary", maxWidth: 360 }}>
+            Review every word and character from this lesson — with audio, playback speed,
+            and a place to record yourself.
+          </Typography>
+          <ReviewTermsButton href={lessonReviewHref(lesson.slug)} complete={complete} />
+        </Box>
+      ))
+    );
+  }
 
   return steps;
 }
@@ -236,11 +285,18 @@ const LessonRunner: React.FC<{
 
   const answeredRef = useRef<Record<string, boolean>>({});
   const resumedRef = useRef(false);
+  /*
+   * How the review screen's link finishes the lesson before it navigates.
+   * Held in a ref rather than passed down because `buildSteps` runs in a memo
+   * that must not re-run when the cursor or the accuracy moves, and the write
+   * needs both — see the effect below that keeps it current.
+   */
+  const completeRef = useRef<(() => Promise<boolean>) | null>(null);
 
   const slug = lesson.slug;
 
   const steps = useMemo(
-    () => buildSteps(lesson, stepSeed({ userId, lessonId: slug, attempt })),
+    () => buildSteps(lesson, stepSeed({ userId, lessonId: slug, attempt }), completeRef),
     [lesson, userId, slug, attempt]
   );
 
@@ -367,6 +423,20 @@ const LessonRunner: React.FC<{
     setStep(next);
     void save("in_progress", next, accuracyPct);
   }
+
+  /*
+   * Deliberately re-assigned on every render: the review link can be clicked at
+   * any point after the last step is reached, and it has to save the cursor and
+   * accuracy as they are then, not as they were when the steps were built.
+   */
+  useEffect(() => {
+    completeRef.current = async () => {
+      setSaving(true);
+      const ok = await save("completed", step, accuracy);
+      setSaving(false);
+      return ok;
+    };
+  });
 
   const handleResult = ({ result }: { result: "correct" | "incorrect" }) => {
     if (!active) return;

--- a/src/payload/blocks/library.ts
+++ b/src/payload/blocks/library.ts
@@ -370,13 +370,14 @@ export const MatchPairs: Block = {
       options: [
         { label: "Word ↔ English meaning", value: "meaning" },
         { label: "Word ↔ reading", value: "reading" },
-        { label: "Hiragana ↔ katakana", value: "kana" },
+        { label: "Audio ↔ hiragana", value: "kana" },
         { label: "Audio ↔ word", value: "audio" },
       ],
       admin: {
         description:
-          "What the two sides are. Hiragana ↔ katakana is what the old \"あ/ア\" strings encoded " +
-          "with a slash; it reads both scripts off the term now.",
+          "What the two sides are. Audio ↔ hiragana is where the old \"あ/ア\" strings ended up: " +
+          "katakana is withheld for now, so that exercise plays the term's recording on the left " +
+          "and asks for its hiragana. Every term in it needs audio.",
       },
       validate: pairingIsPossible,
     },
@@ -646,7 +647,8 @@ function termHasAudio(value: unknown, { siblingData: _siblingData }: SiblingArgs
 function pairingIsPossible(value: unknown, _args: SiblingArgs) {
   if (typeof value !== "string" || !value) return "Pick what the two sides are.";
   // Same limitation as `termHasAudio`: the terms are ids here, so "do these
-  // words all have a katakana form?" is a `content:verify` question.
+  // words all have the side this pairing reads off them?" is a `content:verify`
+  // question.
   return true;
 }
 


### PR DESCRIPTION
Ten of the eleven findings from the code review of #85, on top of that branch. The eleventh (`collectLessonTerms` not descending into rich text) is left as a follow-up — noted in a comment on #85.

## The kana exercise — four findings, one bug

`matchPairs` with `pairing: "kana"` now pairs a term's audio with its hiragana, which makes the recording *load-bearing*: the clip **is** the left card. A term without one renders an unlabelled greyed-out speaker, and a second such term renders an identical one — nothing distinguishes the rows, so the screen is unsolvable rather than merely incomplete.

- `RenderBlock.tsx` — drop kana pairs with no recording, the same way an identical pair is dropped. Fewer than two left and the screen renders nothing, which is the existing convention.
- `library.ts` — the CMS option read "Hiragana ↔ katakana" and its description said it reads both scripts off the term. Now "Audio ↔ hiragana", described as what it does, including that every term needs audio.
- `migrate-to-library.ts` + `content/snapshot/lessons.json` — the instruction above the exercise said "Match each hiragana to its katakana". Fixed in the content of record and in the migration that would regenerate it. The migration also stops quarantining on a missing katakana form, which this exercise no longer reads.
- `RenderBlock.tsx` — blank instructions now fall back to a heading that matches the pairing on screen, rather than `DotMatch`'s one kana-specific sentence.
- `verify.ts` — the gap gets a counted warning line of its own, next to the listening one, instead of being folded into the general to-dos where it was easy to miss.

**On the `verify.ts` reporting level.** The review's finding was that this PR removed the check that would have caught the unsolvable screen. It did — but the right repair turned out to be a warning rather than a failure. What a kana pair needs *structurally* is the written form on its right, and every term has one; the missing recording is an editorial gap whose fix is ten clips, not a code change. That is the reasoning already written down for `listenAndChoose`, which leaves 21 unplayable screens as a counted warning rather than a red build — and making the neighbouring case a hard failure would only mean the check gets switched off. A block with fewer than two structurally usable pairs still fails, as it did before this PR.

Both kana blocks in the content have five terms each and none of the ten has a recording, so those two screens render nothing until the clips land. `docs/content-backlog.md` now counts them against the same ten terms it already tracked.

## Lesson completion

`LessonRunner.tsx` — the review screen is the last step and its link was the only thing on it, so a learner who took it navigated away before the awaited `save("completed")` resolved and the lesson stayed `in_progress`. The link now finishes the lesson first, and stays put if that write fails so the existing error banner can offer the retry.

The review step is also no longer pushed when the lesson references no terms, where it promised a page that could only say there was nothing to review.

## Audio

- `DragDropCombination.tsx` — `showTileAudio` tested `tileAudio?.length`, which is one entry per tile whether or not that tile has a clip. Every correct buildSentence answer put "Hear each piece" above a row of inert grey buttons; it now tests whether any entry exists.
- `MatchDots.tsx` — `playAudio` never stopped the previous clip, so two cards clicked in quick succession played over each other on the one exercise whose task is telling recordings apart. It now stops the previous one and clears the equalizer icon via `onerror` when a clip dies mid-stream.
- Both components pause their detached `Audio` on unmount instead of playing on over the next screen.

## Live Preview

`lessons/[slug]/review/page.tsx` had no `getPreviewEditor()` branch, unlike the sibling lesson route, so an editor following "Review terms" from Live Preview on an unpublished draft was redirected to /dashboard. Added, with draft access still decided by `getPreviewEditor`.

## Verification

`npm run typecheck` and `npm test` (96 passing) are green. `content:verify` runs in CI against a Neon branch and could not be run locally; the first push had it red on the two kana blocks, which is what prompted the reporting-level change above.