### PR TITLE
Collect lesson terms from rich text, not just block relationships

### DIFF
--- a/src/features/exercises/components/RenderBlock.tsx
+++ b/src/features/exercises/components/RenderBlock.tsx
@@ -498,9 +498,10 @@ const BuildSentenceView: React.FC<
   /*
    * A tile is authored as a plain string — "あ", not a term reference — so
    * there is nothing on the block itself to play. Reading/writing lessons
-   * introduce every kana as its own term earlier in the same lesson (the
-   * `vocabList`/`spotlight` steps `collectLessonTerms` also walks), so a
-   * tile's own audio is found by matching its written form against those.
+   * introduce every kana as its own term earlier in the same lesson — in a
+   * `vocabList`/`spotlight` step, or in prose as a `termRef`, both of which
+   * `collectLessonTerms` walks — so a tile's own audio is found by matching
+   * its written form against those.
    * A tile with no matching term, or a term with no recording yet, plays
    * nothing — same silent-gap handling as every other audio button here.
    */

--- a/src/lib/content/lessonTerms.test.ts
+++ b/src/lib/content/lessonTerms.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectLessonTerms } from "./lessonTerms";
+import type { Lesson, Term } from "../../payload/payload-types";
+
+/*
+ * What breaks here breaks quietly. A term this misses is not an error anywhere:
+ * the review page renders one card fewer, and `audioForTile` returns undefined
+ * so a tile's play button simply does not appear. Both look exactly like
+ * content nobody has authored yet, which is why the rich-text gap survived as
+ * long as it did.
+ *
+ * So the cases worth holding are the ones with no visible failure mode:
+ * a term reachable only through Lexical, the first-appearance ordering, and
+ * dedup across the two different ways of referencing the same word.
+ */
+
+const term = (id: number, key: string): Term => ({ id, key }) as Term;
+
+/** A `termRef` inline block as Lexical stores it — the shape prose.ts writes. */
+const termRefNode = (t: Term) => ({
+  type: "inlineBlock",
+  fields: { blockType: "termRef", term: t, display: "furigana" },
+});
+
+/** A rich-text field holding the given inline nodes, in order. */
+const prose = (...nodes: unknown[]) => ({
+  root: { type: "root", children: [{ type: "paragraph", children: nodes }] },
+});
+
+const lesson = (...components: unknown[][]): Lesson =>
+  ({ steps: components.map((c) => ({ components: c })) }) as unknown as Lesson;
+
+const keys = (l: Lesson) => collectLessonTerms(l).map((t) => t.key);
+
+test("collects terms from the relationship fields of exercise blocks", () => {
+  const l = lesson(
+    [{ blockType: "vocabList", terms: [term(1, "a"), term(2, "b")] }],
+    [{ blockType: "buildSentence", term: term(3, "c") }],
+    [{ blockType: "listenAndChoose", term: term(4, "d"), distractors: [term(5, "e")] }]
+  );
+  assert.deepEqual(keys(l), ["a", "b", "c", "d", "e"]);
+});
+
+test("finds a term referenced only from inside rich text", () => {
+  // The regression this function was rewritten for: a word taught in prose and
+  // nowhere else. The old blockType switch never descended into the document.
+  const l = lesson([{ blockType: "prose", body: prose(termRefNode(term(1, "arigatou"))) }]);
+  assert.deepEqual(keys(l), ["arigatou"]);
+});
+
+test("finds a term nested deeper than the top level of a block", () => {
+  // Rich text can sit inside an array inside a block, which is why the walk is
+  // recursive rather than a fixed set of field lookups.
+  const l = lesson([
+    {
+      blockType: "dialogue",
+      lines: [
+        { speaker: "A", body: prose({ type: "text", text: "hello" }) },
+        { speaker: "B", body: prose(termRefNode(term(7, "hajimemashite"))) },
+      ],
+    },
+  ]);
+  assert.deepEqual(keys(l), ["hajimemashite"]);
+});
+
+test("de-dupes a term referenced twice, keeping the first appearance", () => {
+  const shared = term(1, "desu");
+  const l = lesson(
+    [{ blockType: "vocabList", terms: [shared, term(2, "kore")] }],
+    [{ blockType: "listenAndChoose", term: term(3, "sore"), distractors: [shared] }]
+  );
+  assert.deepEqual(keys(l), ["desu", "kore", "sore"]);
+});
+
+test("de-dupes across a rich-text reference and a relationship field", () => {
+  // The two paths reach the same word by different routes; a term is one term.
+  const shared = term(1, "sumimasen");
+  const l = lesson(
+    [{ blockType: "prose", body: prose(termRefNode(shared)) }],
+    [{ blockType: "vocabList", terms: [shared] }]
+  );
+  assert.deepEqual(keys(l), ["sumimasen"]);
+});
+
+test("orders a prose term before a later block's term", () => {
+  // First-appearance order is the documented contract — a learner should meet a
+  // word in the list where they met it in the lesson.
+  const l = lesson(
+    [{ blockType: "prose", body: prose(termRefNode(term(1, "first"))) }],
+    [{ blockType: "vocabList", terms: [term(2, "second")] }]
+  );
+  assert.deepEqual(keys(l), ["first", "second"]);
+});
+
+test("skips an unpopulated relationship rather than emitting a bare id", () => {
+  // Too shallow a read gives back a number. There is no term to show; dropping
+  // it is what content:verify already fails on, so it must not crash or leak.
+  const l = lesson([{ blockType: "vocabList", terms: [1, term(2, "real")] }]);
+  assert.deepEqual(keys(l), ["real"]);
+});
+
+test("does not descend into a term's own fields", () => {
+  // A Term is terminal. Were the walk to recurse into one, a relationship on
+  // the term itself would pull in words this lesson never taught.
+  const nested = { ...term(1, "outer"), term: term(99, "should-not-appear") } as Term;
+  const l = lesson([{ blockType: "buildSentence", term: nested }]);
+  assert.deepEqual(keys(l), ["outer"]);
+});
+
+test("a lesson with no steps yields nothing", () => {
+  assert.deepEqual(collectLessonTerms({} as Lesson), []);
+  assert.deepEqual(collectLessonTerms({ steps: null } as unknown as Lesson), []);
+});

--- a/src/lib/content/lessonTerms.ts
+++ b/src/lib/content/lessonTerms.ts
@@ -2,52 +2,88 @@ import type { Lesson, Term } from "../../payload/payload-types";
 
 /*
  * Every term a lesson actually teaches, read off its blocks rather than
- * authored separately — a lesson has no `terms` field of its own, only the
- * five block types below that reference one.
+ * authored separately — a lesson has no `terms` field of its own.
  *
  * De-duped by id, in first-appearance order: a term introduced in a
  * `vocabList` and later drawn on as a `listenAndChoose` distractor should
  * only show up once, where a learner first met it.
+ *
+ * ── Why this walks for keys instead of switching on blockType ────────────────
+ *
+ * It used to switch on the five block types with a term relationship, which
+ * missed the sixth place a term can be referenced: a `termRef` inline block
+ * inside a rich-text document (`payload/fields/prose.ts`). A term taught only
+ * in a `prose` or `dialogue` block is still taught, and it was invisible here —
+ * so the review page left it out, and `audioForTile` could not find the
+ * recording for a `buildSentence` tile introduced that way.
+ *
+ * A switch also has to be kept in step with the block library by hand, and the
+ * comment naming its five types had already drifted. Walking for the keys a
+ * term hangs off has neither problem, and `termRef` needs no special case: its
+ * relationship sits at `fields.term`, so the same key rule reaches it.
  */
 
 type LessonStep = NonNullable<Lesson["steps"]>[number];
-type LessonBlock = LessonStep["components"][number];
 
-function asTerm(value: Term | number | null | undefined): Term | null {
-  return value && typeof value === "object" ? value : null;
-}
+/**
+ * The keys a catalogue term hangs off, across every block that references one:
+ * `terms` (vocabList, matchPairs), `term` (listenAndChoose, buildSentence,
+ * speakAndScore, and the `termRef` inline block) and `distractors`
+ * (listenAndChoose). No other field in the library carries one.
+ */
+const TERM_KEYS = new Set(["term", "terms", "distractors"]);
 
 export function collectLessonTerms(lesson: Lesson): Term[] {
   const seen = new Set<number>();
   const terms: Term[] = [];
 
-  const add = (value: Term | number | null | undefined) => {
-    const term = asTerm(value);
-    if (!term || seen.has(term.id)) return;
+  const add = (value: unknown): void => {
+    /*
+     * A bare id rather than an object means the read did not populate deeply
+     * enough. There is no term to show either way, and it is not this
+     * function's job to report it — `content:verify` fails on exactly that,
+     * which is why `CONTENT_DEPTH` is 2.
+     */
+    if (!value || typeof value !== "object") return;
+
+    const term = value as Term;
+    if (typeof term.id !== "number" || seen.has(term.id)) return;
+
     seen.add(term.id);
     terms.push(term);
   };
 
-  for (const step of lesson.steps ?? []) {
-    for (const block of (step.components ?? []) as LessonBlock[]) {
-      switch (block.blockType) {
-        case "vocabList":
-        case "matchPairs":
-          (block.terms ?? []).forEach(add);
-          break;
-        case "listenAndChoose":
-          add(block.term);
-          (block.distractors ?? []).forEach(add);
-          break;
-        case "buildSentence":
-        case "speakAndScore":
-          add(block.term);
-          break;
-        default:
-          break;
-      }
+  /*
+   * One walk over the raw block rather than a traversal per field type: blocks
+   * nest arrays inside blocks inside arrays and a rich-text field can appear at
+   * any level, so the shape of that tree is not worth encoding a second time.
+   * The same argument `scripts/content/verify.ts` makes for its own walk.
+   *
+   * Key order is insertion order, which for a document read out of Payload is
+   * the order it was authored in — that is what keeps the result in
+   * first-appearance order rather than something arbitrary.
+   */
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
     }
-  }
+    if (!node || typeof node !== "object") return;
+
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (TERM_KEYS.has(key)) {
+        // Terminal: a term's own fields are not somewhere another term hides,
+        // and descending into one would collect words this lesson never taught.
+        if (Array.isArray(value)) value.forEach(add);
+        else add(value);
+        continue;
+      }
+
+      if (value && typeof value === "object") walk(value);
+    }
+  };
+
+  for (const step of (lesson.steps ?? []) as LessonStep[]) walk(step.components);
 
   return terms;
 }


### PR DESCRIPTION
The one finding from the review of #85 that was held back for standalone work with tests. Now that #85 has merged, this sits on `main` — three files, no overlap with anything else in flight.

## The bug

`collectLessonTerms` switched on the five block types with a term relationship. That missed the sixth place a term can be referenced: a `termRef` inline block inside a rich-text document (`payload/fields/prose.ts`). A term taught only in a `prose` or `dialogue` block was invisible to it.

Nothing errors, which is why it survived. Both consumers just show less:

- the review page renders one card fewer for a term taught only in prose
- `audioForTile` (`RenderBlock.tsx`) finds no match for a `buildSentence` tile whose term is introduced that way, so its play button never appears

Both look exactly like content nobody has authored yet.

## The change

It walks for the keys a term hangs off — `term`, `terms`, `distractors` — instead of switching on `blockType`. `termRef` needs no special case: its relationship sits at `fields.term`, so the same key rule reaches it. That's the whole fix, and it also retires a list that had to be kept in step with the block library by hand and had already drifted — the header comment named five block types as though that were all of them.

Two properties worth naming, both covered by tests:

- **Recursive**, because rich text can sit at any depth inside a block (a `dialogue` line, an array inside a block). Same argument `scripts/content/verify.ts` makes for its own walk.
- **Terminal at a term**, because descending into one would collect words the lesson never taught.

Key order is insertion order, which for a document read out of Payload is authoring order — that is what preserves the documented first-appearance ordering rather than something arbitrary.

## Tests

`lessonTerms.test.ts` is new; the module had no coverage, though four sibling modules in `src/lib/content/` do. Nine cases, aimed at the failure modes that are invisible rather than loud:

- terms from the ordinary relationship fields (the pre-existing behaviour, pinned)
- a term reachable **only** through Lexical — the regression itself
- one nested inside a dialogue line, deeper than a block's top level
- dedup of a term referenced twice, keeping first appearance
- dedup across a rich-text reference and a relationship field
- ordering between a prose term and a later block's term
- an unpopulated relationship arriving as a bare id
- a term's own fields not being descended into
- a lesson with no steps

## Verification

`npm run typecheck` clean; `npm test` 105 passing (96 on `main`, 9 new). Both re-run after rebasing onto the merged `main` rather than only on the pre-merge base.

## Note

`RenderBlock.tsx` carries a one-line comment change: it described a tile's audio as coming from the `vocabList`/`spotlight` steps, which is now narrower than the truth.

---
_Generated by [Claude Code](https://claude.ai/code/session_014e6ykVo9bAQTFkA4UzoKQM)_