### PR TITLE
Replace deprecated motion() with motion.create() on the home page

### DIFF
--- a/src/app/(app)/(public)/Home.tsx
+++ b/src/app/(app)/(public)/Home.tsx
@@ -20,7 +20,7 @@ import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { useSession } from "@/lib/auth-client";
 
-const MotionCard = motion(Card);
+const MotionCard = motion.create(Card);
 const EASE = [0.16, 1, 0.3, 1] as const;
 
 const Home = (): React.ReactElement => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was going on

`npm run dev` was already working. The homepage returned `GET / 200`, and `GET /api/auth/get-session 200` means a browser actually loaded the page.

The terminal staying on those logs is expected: Next.js does not open a window. Open [http://localhost:3000](http://localhost:3000) while the process is running.

The only code issue in those logs is the Framer Motion warning:

```
motion() is deprecated. Use motion.create() instead.
```

Next reports it as `src/pages-client/Home.tsx:23:26`, but that path is a provenance comment. The live file is `src/app/(app)/(public)/Home.tsx`. Edits to a `pages-client` path will not show up.

## Change

- `motion(Card)` → `motion.create(Card)` for the homepage feature cards (the only remaining factory call)

This is a console-warning fix. It does not change layout or behavior.

## Checks

- `npm run typecheck` passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84550dda-85ba-4259-8e9d-3912242f173c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84550dda-85ba-4259-8e9d-3912242f173c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

